### PR TITLE
Replace System.currentTimeMillis with DateTimeUtils.currentTimeMillis.

### DIFF
--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -1,6 +1,6 @@
 package com.nitorcreations.nflow.engine.internal.dao;
 
-import static java.lang.System.currentTimeMillis;
+import static org.joda.time.DateTimeUtils.currentTimeMillis;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.collectionToDelimitedString;

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/H2ModifiedColumnTrigger.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/H2ModifiedColumnTrigger.java
@@ -1,6 +1,6 @@
 package com.nitorcreations.nflow.engine.internal.storage.db;
 
-import static java.lang.System.currentTimeMillis;
+import static org.joda.time.DateTimeUtils.currentTimeMillis;
 
 import java.sql.Connection;
 import java.sql.ResultSet;

--- a/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/workflow/definition/WorkflowSettingsTest.java
+++ b/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/workflow/definition/WorkflowSettingsTest.java
@@ -1,6 +1,6 @@
 package com.nitorcreations.nflow.engine.workflow.definition;
 
-import static java.lang.System.currentTimeMillis;
+import static org.joda.time.DateTimeUtils.currentTimeMillis;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;

--- a/nflow-jetty/src/main/java/com/nitorcreations/nflow/jetty/StartNflow.java
+++ b/nflow-jetty/src/main/java/com/nitorcreations/nflow/jetty/StartNflow.java
@@ -1,7 +1,7 @@
 package com.nitorcreations.nflow.jetty;
 
 import static java.lang.String.valueOf;
-import static java.lang.System.currentTimeMillis;
+import static org.joda.time.DateTimeUtils.currentTimeMillis;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.eclipse.jetty.servlet.ServletContextHandler.NO_SECURITY;

--- a/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/runner/NflowServerRule.java
+++ b/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/runner/NflowServerRule.java
@@ -1,9 +1,9 @@
 package com.nitorcreations.nflow.tests.runner;
 
-import static java.lang.System.currentTimeMillis;
 import static org.apache.commons.lang.StringUtils.substringAfterLast;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.right;
+import static org.joda.time.DateTimeUtils.currentTimeMillis;
 import static org.junit.Assert.assertTrue;
 
 import java.util.LinkedHashMap;


### PR DESCRIPTION
The change makes possible to control time in unit tests.
