### PR TITLE
Move runtime dep of swagger in nflow-jetty to build time dep in nflow-rest-api

### DIFF
--- a/nflow-jetty/pom.xml
+++ b/nflow-jetty/pom.xml
@@ -139,10 +139,6 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.wordnik</groupId>
-      <artifactId>swagger-jaxrs_2.10</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/nflow-jetty/src/main/java/com/nitorcreations/nflow/jetty/StartNflow.java
+++ b/nflow-jetty/src/main/java/com/nitorcreations/nflow/jetty/StartNflow.java
@@ -165,6 +165,7 @@ public class StartNflow
 
     logger.info("Static resources served from {}", resources);
     context.setBaseResource(new ResourceCollection(resources.toArray(new String[resources.size()])));
+    context.setWelcomeFiles(new String[] { "index.html", "service.json" });
 
     ServletHolder holder = new ServletHolder(new DefaultServlet());
     holder.setInitParameter("dirAllowed", "false");

--- a/nflow-jetty/src/main/resources/static/doc/index.html
+++ b/nflow-jetty/src/main/resources/static/doc/index.html
@@ -23,7 +23,7 @@
   <script type="text/javascript">
     $(function () {
       window.swaggerUi = new SwaggerUi({
-      url: location.protocol + '//' + location.host + location.pathname + "../api/api-docs",
+      url: "../api-docs",
       dom_id: "swagger-ui-container",
       supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
       onComplete: function(swaggerApi, swaggerUi){

--- a/nflow-jetty/src/test/java/com/nitorcreations/nflow/jetty/config/NflowJettyConfigurationTest.java
+++ b/nflow-jetty/src/test/java/com/nitorcreations/nflow/jetty/config/NflowJettyConfigurationTest.java
@@ -1,19 +1,13 @@
 package com.nitorcreations.nflow.jetty.config;
 
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
-
-import com.wordnik.swagger.jaxrs.config.BeanConfig;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NflowJettyConfigurationTest {
@@ -22,24 +16,7 @@ public class NflowJettyConfigurationTest {
   private Environment env;
 
   @Test
-  public void swaggerBasepathBuildingWorks() {
-    when(env.getProperty(eq("swagger.basepath.protocol"), anyString())).thenReturn("https");
-    when(env.getProperty(eq("swagger.basepath.server"), anyString())).thenReturn("foobar");
-    when(env.getProperty(eq("swagger.basepath.port"), eq(Integer.class), anyInt())).thenReturn(123);
-    when(env.getProperty(eq("swagger.basepath.context"), anyString())).thenReturn("/nflow");
-    NflowJettyConfiguration config = new NflowJettyConfiguration();
-    config.env = env;
-    BeanConfig swaggerConfig = config.swaggerConfig();
-    assertThat(swaggerConfig.getBasePath(), is("https://foobar:123/nflow"));
+  public void createsValidationExceptionMapper() {
+    assertThat(new NflowJettyConfiguration().validationExceptionMapper(), notNullValue());
   }
-
-  @Test
-  public void swaggerBasepathPropertyWorks() {
-    when(env.getProperty("swagger.basepath")).thenReturn("https://bar:123/foo");
-    NflowJettyConfiguration config = new NflowJettyConfiguration();
-    config.env = env;
-    BeanConfig swaggerConfig = config.swaggerConfig();
-    assertThat(swaggerConfig.getBasePath(), is("https://bar:123/foo"));
-  }
-
 }

--- a/nflow-rest-api/pom.xml
+++ b/nflow-rest-api/pom.xml
@@ -9,6 +9,9 @@
     <groupId>com.nitorcreations</groupId>
     <version>1.1.1-SNAPSHOT</version>
   </parent>
+  <properties>
+    <EMPTY></EMPTY>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.nitorcreations</groupId>
@@ -26,7 +29,7 @@
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-annotations</artifactId>
-    </dependency> 
+    </dependency>
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
@@ -65,4 +68,68 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <version>${maven-swagger.version}</version>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <locations>com.nitorcreations.nflow.rest</locations>
+              <apiVersion>${project.version}</apiVersion>
+              <swaggerDirectory>${project.build.outputDirectory}/swagger-docs</swaggerDirectory>
+              <basePath>../api</basePath>
+              <swaggerUIDocBasePath>@EMPTY@</swaggerUIDocBasePath>
+              <swaggerApiReader>com.wordnik.swagger.jersey.JerseyApiReader</swaggerApiReader>
+              <!--<swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader> -->
+            </apiSource>
+          </apiSources>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.wordnik</groupId>
+            <artifactId>swagger-jersey-jaxrs_2.10</artifactId>
+            <version>${swagger.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.wordnik</groupId>
+            <artifactId>swagger-jaxrs_2.10</artifactId>
+<version>${swagger.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/static/api-docs</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.build.outputDirectory}/swagger-docs</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/nflow-tests/src/main/java/com/nitorcreations/nflow/tests/demo/DemoServer.java
+++ b/nflow-tests/src/main/java/com/nitorcreations/nflow/tests/demo/DemoServer.java
@@ -3,10 +3,6 @@ package com.nitorcreations.nflow.tests.demo;
 import com.nitorcreations.nflow.jetty.StartNflow;
 import com.nitorcreations.nflow.metrics.NflowMetricsContext;
 
-/**
- * To enable swagger ui (http://localhost:7500/docs) Execute "mvn compile"
- * before starting.
- */
 public class DemoServer {
   public static void main(String[] args) throws Exception {
     new StartNflow().registerSpringContext(NflowMetricsContext.class).startJetty(7500, "local", "jmx");

--- a/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/runner/NflowServerRule.java
+++ b/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/runner/NflowServerRule.java
@@ -1,8 +1,8 @@
 package com.nitorcreations.nflow.tests.runner;
 
-import static org.apache.commons.lang.StringUtils.substringAfterLast;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.right;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
 import static org.joda.time.DateTimeUtils.currentTimeMillis;
 import static org.junit.Assert.assertTrue;
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
     <maven-site.version>3.4</maven-site.version>
     <maven-source.version>2.4</maven-source.version>
     <maven-surefire.version>2.18</maven-surefire.version>
+    <maven-swagger.version>2.3.1</maven-swagger.version>
     <mockito.version>1.10.8</mockito.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>5.1.34</mysql.version>


### PR DESCRIPTION
Managed to hack all the swagger json basePaths to be relative -> much easier to expose behing a proxy.
