### PR TITLE
Update dependencies:

### DIFF
--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/DatabaseConfiguration.java
@@ -33,8 +33,8 @@ public abstract class DatabaseConfiguration {
     HikariConfig config = new HikariConfig();
     config.setDataSourceClassName(property(env, "driver"));
     config.addDataSourceProperty("url", url);
-    config.addDataSourceProperty("user", property(env, "user"));
-    config.addDataSourceProperty("password", property(env, "password"));
+    config.setUsername(property(env, "user"));
+    config.setPassword(property(env, "password"));
     config.setMaximumPoolSize(property(env, "max_pool_size", Integer.class));
     return new HikariDataSource(config);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,11 @@
     <hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
     <hikaricp.version>2.2.5</hikaricp.version>
     <jackson.version>2.5.0</jackson.version>
-    <javassist.version>3.18.2-GA</javassist.version>
+    <javassist.version>3.19.0-GA</javassist.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
     <jetty.version>9.2.6.v20141205</jetty.version>
-    <jodatime.version>2.6</jodatime.version>
+    <jodatime.version>2.7</jodatime.version>
     <junit.version>4.12</junit.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <logback-classic.version>1.1.2</logback-classic.version>
@@ -121,7 +121,7 @@
     <maven-javadoc.version>2.10.1</maven-javadoc.version>
     <maven-jxr.version>2.5</maven-jxr.version>
     <maven-pmd.version>3.3</maven-pmd.version>
-    <maven-project-info.version>2.7</maven-project-info.version>
+    <maven-project-info.version>2.8</maven-project-info.version>
     <maven-release.version>2.5.1</maven-release.version>
     <maven-resources.version>2.7</maven-resources.version>
     <maven-site.version>3.4</maven-site.version>
@@ -136,7 +136,7 @@
     <postgresql.version>9.3-1102-jdbc41</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <slf4j.version>1.7.9</slf4j.version>
+    <slf4j.version>1.7.10</slf4j.version>
     <spring.version>4.1.4.RELEASE</spring.version>
     <swagger.version>1.3.12</swagger.version>
     <validation.api.version>1.1.0.Final</validation.api.version>


### PR DESCRIPTION
javaassist 3.18.2->3.19.0 https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10056&version=12321964&_sscc=t
jodatime 2.6->2.7 http://www.joda.org/joda-time/upgradeto270.html
slf4j 1.7.9->1.7.10 http://www.slf4j.org/news.html
maven-project-info 2.7->2.8 http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=11142&version=19232