### PR TITLE
Add field nflow_instance_action.type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@
   - Only rollback poll operation when no workflows could be allocated for executing (when multiple pollers compete for same workflows)
   - Allow configuring executor queue length with _nflow.dispatcher.executor.queue.size_
   - nflow.transition.delay.waiterror.ms parameter was splitted to nflow.transition.delay.error.min.ms and nflow.transition.delay.error.max.ms
+  - Add field `nflow_instance_action.type` that contains type of action:
+    - *stateExecution* - for actions created with normal execution. This is also set for old actions created before this feature.
+    - *stateExecutionFailed* - for actions where execution failed due thrown exception or retry count was exceeded.
+    - *externalChange* - for changes created externally via API.
+    - *recovery* - to indicate that the workflow instance was recovered after some executor died.
 - nflow-rest:
   - Add support for user-provided action description when updating a workflow instance
   - added missing configuration options with default values
+  - Add support for Action.type
 - nflow-jetty:
   - added missing configuration options with default values
 

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/ExecutorDao.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/ExecutorDao.java
@@ -2,6 +2,7 @@ package com.nitorcreations.nflow.engine.internal.dao;
 
 import static com.nitorcreations.nflow.engine.internal.dao.DaoUtil.toDateTime;
 import static com.nitorcreations.nflow.engine.internal.storage.db.DatabaseConfiguration.NFLOW_DATABASE_INITIALIZER;
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.recovery;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.joda.time.DateTime.now;
@@ -160,7 +161,8 @@ public class ExecutorDao {
           instance.id, getExecutorId());
       if (updated > 0) {
         WorkflowInstanceAction action = new WorkflowInstanceAction.Builder().setExecutionStart(now()).setExecutionEnd(now())
-            .setExecutorId(getExecutorId()).setState(instance.state).setStateText("Recovered").setWorkflowInstanceId(instance.id).build();
+            .setExecutorId(getExecutorId()).setType(recovery).setState(instance.state).setStateText("Recovered")
+            .setWorkflowInstanceId(instance.id).build();
         workflowInstanceDao.insertWorkflowInstanceAction(action);
       }
     }

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/H2DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/H2DatabaseConfiguration.java
@@ -50,5 +50,10 @@ public class H2DatabaseConfiguration extends DatabaseConfiguration {
     public boolean hasUpdateReturning() {
       return false;
     }
+
+    @Override
+    public String castToEnumType(String variable, String type) {
+      return variable;
+    }
   }
 }

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/MysqlDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/MysqlDatabaseConfiguration.java
@@ -68,5 +68,10 @@ public class MysqlDatabaseConfiguration extends DatabaseConfiguration {
     public boolean hasUpdateReturning() {
       return false;
     }
+
+    @Override
+    public String castToEnumType(String variable, String type) {
+      return variable;
+    }
   }
 }

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/PgDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/PgDatabaseConfiguration.java
@@ -27,5 +27,10 @@ public class PgDatabaseConfiguration extends DatabaseConfiguration {
     public boolean hasUpdateReturning() {
       return true;
     }
+
+    @Override
+    public String castToEnumType(String variable, String type) {
+      return variable + "::" + type;
+    }
   }
 }

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/SQLVariants.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/SQLVariants.java
@@ -4,4 +4,6 @@ public interface SQLVariants {
   String currentTimePlusSeconds(int seconds);
 
   boolean hasUpdateReturning();
+
+  String castToEnumType(String variable, String type);
 }

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/workflow/StateExecutionImpl.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/workflow/StateExecutionImpl.java
@@ -18,6 +18,7 @@ public class StateExecutionImpl implements StateExecution {
   private boolean saveTrace = true;
   private Throwable thrown;
   private boolean isFailed;
+  private boolean isRetryCountExceeded;
 
   public StateExecutionImpl(WorkflowInstance instance, ObjectStringMapper objectMapper) {
     this.instance = instance;
@@ -133,6 +134,14 @@ public class StateExecutionImpl implements StateExecution {
   public void setFailed(Throwable t) {
     isFailed = true;
     thrown = t;
+  }
+
+  public boolean isRetryCountExceeded() {
+    return isRetryCountExceeded;
+  }
+
+  public void setRetryCountExceeded() {
+    isRetryCountExceeded = true;
   }
 
 }

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/workflow/definition/AbstractWorkflowDefinition.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/workflow/definition/AbstractWorkflowDefinition.java
@@ -227,6 +227,7 @@ public abstract class AbstractWorkflowDefinition<S extends WorkflowState> {
   public void handleRetryAfter(StateExecutionImpl execution, DateTime activation) {
     if (execution.getRetries() >= getSettings().maxRetries) {
       execution.setRetry(false);
+      execution.setRetryCountExceeded();
       WorkflowState failureState = failureTransitions.get(execution.getCurrentStateName());
       WorkflowState currentState = getState(execution.getCurrentStateName());
       if (failureState != null) {

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/workflow/instance/WorkflowInstanceAction.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/workflow/instance/WorkflowInstanceAction.java
@@ -12,6 +12,27 @@ import org.joda.time.DateTime;
  * An execution of a workflow instance state.
  */
 public class WorkflowInstanceAction {
+  /**
+   * Describes the trigger for the action.
+   */
+  public enum WorkflowActionType {
+    /**
+     * Normal state execution.
+     */
+    stateExecution,
+    /**
+     * Normal state execution that resulted in failure.
+     */
+    stateExecutionFailed,
+    /**
+     * External change to the workflow instance.
+     */
+    externalChange,
+    /**
+     * Dead executor recovery.
+     */
+    recovery
+  }
 
   /**
    * The workflow instance identifier.
@@ -29,6 +50,11 @@ public class WorkflowInstanceAction {
    * The id for executor that processed this state.
    */
   public final int executorId;
+
+  /**
+   * The type of action.
+   */
+  public final WorkflowActionType type;
 
   /**
    * The workflow state before the execution.
@@ -64,6 +90,7 @@ public class WorkflowInstanceAction {
     this.workflowId = builder.workflowInstanceId;
     this.workflowInstanceId = builder.workflowInstanceId;
     this.executorId = builder.executorId;
+    this.type = builder.type;
     this.state = builder.state;
     this.stateText = builder.stateText;
     this.updatedStateVariables = unmodifiableMap(builder.updatedStateVariables);
@@ -79,6 +106,7 @@ public class WorkflowInstanceAction {
 
     int workflowInstanceId;
     int executorId;
+    WorkflowActionType type;
     String state;
     String stateText;
     int retryNo;
@@ -101,6 +129,7 @@ public class WorkflowInstanceAction {
       this.executionStart = action.executionStart;
       this.executorId = action.executorId;
       this.retryNo = action.retryNo;
+      this.type = action.type;
       this.state = action.state;
       this.stateText = action.stateText;
       this.updatedStateVariables.putAll(action.updatedStateVariables);
@@ -149,6 +178,17 @@ public class WorkflowInstanceAction {
       this.executorId = executorId;
       return this;
     }
+
+    /**
+     * Set the trigger type of the action.
+     * @param actionType The action type.
+     * @return this
+     */
+    public Builder setType(WorkflowActionType actionType) {
+      this.type = actionType;
+      return this;
+    }
+
     /**
      * Set the state.
      * @param state The name of the state.
@@ -214,6 +254,9 @@ public class WorkflowInstanceAction {
      * @return The workflow instance action.
      */
     public WorkflowInstanceAction build() {
+      if (type == null) {
+        throw new IllegalStateException("Missing type");
+      }
       return new WorkflowInstanceAction(this);
     }
   }

--- a/nflow-engine/src/main/resources/scripts/db/h2.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/h2.create.ddl.sql
@@ -22,6 +22,7 @@ create table if not exists nflow_workflow_action (
   id int not null auto_increment primary key,
   workflow_id int not null,
   executor_id int not null default -1,
+  type varchar(32) not null default 'stateExecution' check type in ('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange'),
   state varchar(64) not null,
   state_text varchar(128),
   retry_no int not null,

--- a/nflow-engine/src/main/resources/scripts/db/mysql.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/mysql.create.ddl.sql
@@ -19,6 +19,7 @@ create table if not exists nflow_workflow_action (
   id int not null auto_increment primary key,
   workflow_id int not null,
   executor_id int not null default -1,
+  type enum('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange') not null default 'stateExecution',
   state varchar(64) not null,
   state_text varchar(128),
   retry_no int not null,

--- a/nflow-engine/src/main/resources/scripts/db/mysql.legacy.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/mysql.legacy.create.ddl.sql
@@ -24,6 +24,7 @@ create table if not exists nflow_workflow_action (
   id int not null auto_increment primary key,
   workflow_id int not null,
   executor_id int not null default -1,
+  type enum('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange') not null default 'stateExecution',
   state varchar(64) not null,
   state_text varchar(128),
   retry_no int not null,

--- a/nflow-engine/src/main/resources/scripts/db/postgresql.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/postgresql.create.ddl.sql
@@ -27,10 +27,12 @@ create trigger update_nflow_modified before update on nflow_workflow for each ro
 drop index nflow_workflow_activation;
 create index nflow_workflow_activation on nflow_workflow(next_activation) where next_activation is not null;
 
+create type action_type as enum ('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange');
 create table if not exists nflow_workflow_action (
   id serial primary key,
   workflow_id int not null,
   executor_id int not null default -1,
+  type action_type not null default 'stateExecution',
   state varchar(64) not null,
   state_text varchar(128),
   retry_no int not null,

--- a/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/h2.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/h2.update.ddl.sql
@@ -1,2 +1,4 @@
-
 alter table nflow_workflow_definition add definition_sha1 varchar(40) not null default 'n/a';
+
+alter table nflow_workflow_action add type varchar(32) not null default 'stateExecution' check type in ('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange');
+

--- a/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/mysql.legacy.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/mysql.legacy.update.ddl.sql
@@ -1,2 +1,3 @@
-
 alter table nflow_workflow_definition add definition_sha1 varchar(40) not null default 'n/a';
+alter table nflow_workflow_action add type enum('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange') not null default 'stateExecution';
+

--- a/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/mysql.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/mysql.update.ddl.sql
@@ -1,2 +1,3 @@
-
 alter table nflow_workflow_definition add definition_sha1 varchar(40) not null default 'n/a';
+alter table nflow_workflow_action add type enum('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange') not null default 'stateExecution';
+

--- a/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/postgresql.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-1.2.0-x/postgresql.update.ddl.sql
@@ -1,2 +1,4 @@
-
 alter table nflow_workflow_definition add definition_sha1 varchar(40) not null default 'n/a';
+create type action_type as enum ('stateExecution', 'stateExecutionFailed', 'recovery', 'externalChange');
+alter table nflow_workflow_action add type action_type not null default 'stateExecution';
+

--- a/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/internal/dao/ExecutorDaoTest.java
+++ b/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/internal/dao/ExecutorDaoTest.java
@@ -1,5 +1,6 @@
 package com.nitorcreations.nflow.engine.internal.dao;
 
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.recovery;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.joda.time.DateTime.now;
@@ -59,6 +60,7 @@ public class ExecutorDaoTest extends BaseDaoTest {
     assertThat(actions.size(), is(1));
     WorkflowInstanceAction workflowInstanceAction = actions.get(0);
     assertThat(workflowInstanceAction.executorId, is(dao.getExecutorId()));
+    assertThat(workflowInstanceAction.type, is(recovery));
     assertThat(workflowInstanceAction.stateText, is("Recovered"));
   }
 

--- a/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -1,5 +1,6 @@
 package com.nitorcreations.nflow.engine.internal.dao;
 
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.stateExecution;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.min;
 import static java.lang.Thread.sleep;
@@ -108,7 +109,8 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     int id = dao.insertWorkflowInstance(i1);
     DateTime started = DateTime.now();
     WorkflowInstanceAction a1 = new WorkflowInstanceAction.Builder().setExecutionStart(started).setExecutorId(42)
-        .setExecutionEnd(DateTime.now().plusMillis(100)).setRetryNo(1).setState("test").setStateText("state text")
+        .setExecutionEnd(DateTime.now().plusMillis(100)).setRetryNo(1).setType(stateExecution).setState("test")
+        .setStateText("state text")
         .setWorkflowInstanceId(id).build();
     i1.stateVariables.put("b", "2");
     dao.insertWorkflowInstanceAction(i1, a1);

--- a/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/service/WorkflowInstanceServiceTest.java
+++ b/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/service/WorkflowInstanceServiceTest.java
@@ -1,6 +1,7 @@
 package com.nitorcreations.nflow.engine.service;
 
 import static com.nitorcreations.Matchers.containsElementsInAnyOrder;
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.is;
@@ -115,7 +116,7 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
   @Test
   public void updateWorkflowInstanceWorks() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
-    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setWorkflowInstanceId(i.id).build();
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
     when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(i.id, i.state, i.nextActivation)).thenReturn(true);
     assertThat(service.updateWorkflowInstance(i, a), is(true));
@@ -126,7 +127,7 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
   @Test
   public void updateRunningWorkflowInstanceFails() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
-    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().build();
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).build();
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(i.id, i.state, i.nextActivation)).thenReturn(false);
     assertThat(service.updateWorkflowInstance(i, a), is(false));
     verify(workflowInstanceDao, never()).insertWorkflowInstanceAction(any(WorkflowInstance.class),

--- a/nflow-rest-api/src/main/java/com/nitorcreations/nflow/rest/v1/WorkflowInstanceResource.java
+++ b/nflow-rest-api/src/main/java/com/nitorcreations/nflow/rest/v1/WorkflowInstanceResource.java
@@ -1,5 +1,6 @@
 package com.nitorcreations.nflow.rest.v1;
 
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -106,7 +107,7 @@ public class WorkflowInstanceResource {
     }
     WorkflowInstance instance = builder.build();
     boolean updated = workflowInstances.updateWorkflowInstance(instance, new WorkflowInstanceAction.Builder(instance)
-        .setStateText(trimToNull(msg)).setExecutionEnd(now()).build());
+        .setType(externalChange).setStateText(trimToNull(msg)).setExecutionEnd(now()).build());
     return (updated ? noContent() : status(CONFLICT)).build();
   }
 

--- a/nflow-rest-api/src/main/java/com/nitorcreations/nflow/rest/v1/converter/ListWorkflowInstanceConverter.java
+++ b/nflow-rest-api/src/main/java/com/nitorcreations/nflow/rest/v1/converter/ListWorkflowInstanceConverter.java
@@ -47,10 +47,10 @@ public class ListWorkflowInstanceConverter {
       resp.actions = new ArrayList<>();
       for (WorkflowInstanceAction action : instance.actions) {
         if(query.includeActionStateVariables) {
-          resp.actions.add(new Action(action.state, action.stateText, action.retryNo,
+          resp.actions.add(new Action(action.type.name(), action.state, action.stateText, action.retryNo,
               action.executionStart, action.executionEnd, action.executorId, stateVariablesToJson(action.updatedStateVariables)));
         } else {
-          resp.actions.add(new Action(action.state, action.stateText, action.retryNo,
+          resp.actions.add(new Action(action.type.name(), action.state, action.stateText, action.retryNo,
               action.executionStart, action.executionEnd, action.executorId));
         }
       }

--- a/nflow-rest-api/src/main/java/com/nitorcreations/nflow/rest/v1/msg/Action.java
+++ b/nflow-rest-api/src/main/java/com/nitorcreations/nflow/rest/v1/msg/Action.java
@@ -13,6 +13,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD", justification = "jackson reads dto fields")
 public class Action {
 
+  @ApiModelProperty(value = "Type of state: 'stateExecution', 'stateExecutionFailed', 'externalChange' or 'recovery'.")
+  public String type;
   @ApiModelProperty(value = "Name of state")
   public String state;
   @ApiModelProperty(value = "Description of state")
@@ -31,13 +33,14 @@ public class Action {
   public Action() {
   }
 
-  public Action(String state, String stateText, int retryNo, DateTime executionStartTime, DateTime executionEndTime,
+  public Action(String type, String state, String stateText, int retryNo, DateTime executionStartTime, DateTime executionEndTime,
       int executorId) {
-    this(state, stateText, retryNo, executionStartTime, executionEndTime, executorId, null);
+    this(type, state, stateText, retryNo, executionStartTime, executionEndTime, executorId, null);
   }
 
-  public Action(String state, String stateText, int retryNo, DateTime executionStartTime, DateTime executionEndTime,
+  public Action(String type, String state, String stateText, int retryNo, DateTime executionStartTime, DateTime executionEndTime,
       int executorId, Map<String, Object> updatedStateVariables) {
+    this.type = type;
     this.state = state;
     this.stateText = stateText;
     this.retryNo = retryNo;

--- a/nflow-rest-api/src/test/java/com/nitorcreations/nflow/rest/v1/WorkflowInstanceResourceTest.java
+++ b/nflow-rest-api/src/test/java/com/nitorcreations/nflow/rest/v1/WorkflowInstanceResourceTest.java
@@ -1,6 +1,7 @@
 package com.nitorcreations.nflow.rest.v1;
 
 import static com.nitorcreations.Matchers.hasField;
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyCollectionOf;
@@ -94,8 +95,9 @@ public class WorkflowInstanceResourceTest {
     req.state = "newState";
     req.actionDescription = "description";
     resource.updateWorkflowInstance(3, req);
-    verify(workflowInstances).updateWorkflowInstance((WorkflowInstance) argThat(hasField("state", equalTo(req.state))),
-        (WorkflowInstanceAction) argThat(hasField("stateText", equalTo("description"))));
+    verify(workflowInstances).updateWorkflowInstance(
+        (WorkflowInstance) argThat(hasField("state", equalTo(req.state))),
+        (WorkflowInstanceAction) argThat(allOf(hasField("stateText", equalTo("description")), hasField("type", equalTo(externalChange)))));
   }
 
   @Test
@@ -106,8 +108,8 @@ public class WorkflowInstanceResourceTest {
     resource.updateWorkflowInstance(3, req);
     verify(workflowInstances).updateWorkflowInstance(
         (WorkflowInstance) argThat(hasField("state", equalTo(null))),
-        (WorkflowInstanceAction) argThat(hasField("stateText", equalTo("API changed nextActivationTime to "
-            + req.nextActivationTime + "."))));
+        (WorkflowInstanceAction) argThat(allOf(hasField("stateText", equalTo("API changed nextActivationTime to "
+            + req.nextActivationTime + ".")), hasField("type", equalTo(externalChange)))));
   }
 
   @Test
@@ -117,8 +119,9 @@ public class WorkflowInstanceResourceTest {
     req.nextActivationTime = new DateTime(2014, 11, 12, 17, 55, 0);
     req.actionDescription = "description";
     resource.updateWorkflowInstance(3, req);
-    verify(workflowInstances).updateWorkflowInstance((WorkflowInstance) argThat(hasField("state", equalTo(null))),
-        (WorkflowInstanceAction) argThat(hasField("stateText", equalTo("description"))));
+    verify(workflowInstances).updateWorkflowInstance(
+        (WorkflowInstance) argThat(hasField("state", equalTo(null))),
+        (WorkflowInstanceAction) argThat(allOf(hasField("stateText", equalTo("description")), hasField("type", equalTo(externalChange)))));
   }
 
   @SuppressWarnings("unchecked")

--- a/nflow-rest-api/src/test/java/com/nitorcreations/nflow/rest/v1/converter/ListWorkflowInstanceConverterTest.java
+++ b/nflow-rest-api/src/test/java/com/nitorcreations/nflow/rest/v1/converter/ListWorkflowInstanceConverterTest.java
@@ -1,6 +1,7 @@
 package com.nitorcreations.nflow.rest.v1.converter;
 
 import static com.nitorcreations.Matchers.reflectEquals;
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.stateExecution;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -42,7 +43,7 @@ public class ListWorkflowInstanceConverterTest {
 
   @Test
   public void convertWithActionsWorks() throws IOException {
-    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setState("oState").setStateText("oState desc").
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(stateExecution).setState("oState").setStateText("oState desc").
         setRetryNo(1).setExecutionStart(now().minusDays(1)).setExecutionEnd(now().plusDays(1)).setExecutorId(999).build();
     Map<String, String> stateVariables = new LinkedHashMap<>();
     stateVariables.put("foo", "1");
@@ -74,13 +75,13 @@ public class ListWorkflowInstanceConverterTest {
     assertThat(resp.modified, is(i.modified));
     assertThat(resp.started, is(i.started));
     assertThat(resp.retries, is(i.retries));
-    assertThat(resp.actions, contains(reflectEquals(new Action(a.state, a.stateText, a.retryNo,
+    assertThat(resp.actions, contains(reflectEquals(new Action(a.type.name(), a.state, a.stateText, a.retryNo,
         a.executionStart, a.executionEnd, a.executorId))));
   }
 
   @Test
   public void convertWithoutActionsWorks() {
-    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setState("oState").setStateText("oState desc").
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(stateExecution).setState("oState").setStateText("oState desc").
         setRetryNo(1).setExecutionStart(now().minusDays(1)).setExecutionEnd(now().plusDays(1)).build();
     WorkflowInstance i = new WorkflowInstance.Builder().setId(1).setType("dummy").setBusinessKey("businessKey").
         setExternalId("externalId").setState("cState").setStateText("cState desc").setNextActivation(now())
@@ -100,7 +101,7 @@ public class ListWorkflowInstanceConverterTest {
 
   @Test
   public void convertWithoutStateVariablesWorks() {
-    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setState("oState").setStateText("oState desc").
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(stateExecution).setState("oState").setStateText("oState desc").
         setRetryNo(1).setExecutionStart(now().minusDays(1)).setExecutionEnd(now().plusDays(1)).build();
     WorkflowInstance i = new WorkflowInstance.Builder().setId(1).setType("dummy").setBusinessKey("businessKey").
         setExternalId("externalId").setState("cState").setStateText("cState desc").setNextActivation(now())
@@ -121,7 +122,7 @@ public class ListWorkflowInstanceConverterTest {
 
   @Test
   public void convertWithEmptyStateVariablesWorks() {
-    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setState("oState").setStateText("oState desc").
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(stateExecution).setState("oState").setStateText("oState desc").
         setRetryNo(1).setExecutionStart(now().minusDays(1)).setExecutionEnd(now().plusDays(1)).build();
     WorkflowInstance i = new WorkflowInstance.Builder().setId(1).setType("dummy").setBusinessKey("businessKey").
         setExternalId("externalId").setState("cState").setStateText("cState desc").setNextActivation(now())
@@ -142,7 +143,7 @@ public class ListWorkflowInstanceConverterTest {
 
   @Test
   public void convertWithMalformedStateVariablesWorks() throws JsonProcessingException, IOException {
-    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setState("oState").setStateText("oState desc").
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(stateExecution).setState("oState").setStateText("oState desc").
         setRetryNo(1).setExecutionStart(now().minusDays(1)).setExecutionEnd(now().plusDays(1)).build();
     Map<String, String> stateVariables = new LinkedHashMap<>();
     String value1 = "{\"a\":1";

--- a/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/CreditApplicationWorkflowTest.java
+++ b/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/CreditApplicationWorkflowTest.java
@@ -1,5 +1,6 @@
 package com.nitorcreations.nflow.tests;
 
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.stateExecution;
 import static java.util.Arrays.asList;
 import static org.apache.cxf.jaxrs.client.WebClient.fromClient;
 import static org.hamcrest.Matchers.notNullValue;
@@ -75,14 +76,14 @@ public class CreditApplicationWorkflowTest extends AbstractNflowTest {
   @Test
   public void t05_checkWorkflowInstanceActions() {
     assertWorkflowInstance(resp.id, actionHistoryValidator(asList(
-            new Action("createCreditApplication", "", 0, null, null, 0),
-            new Action("acceptCreditApplication", "", 0, null, null, 0), // probably not the way to show manual action in future
-            new Action("grantLoan", "", 0, null, null, 0),
-            new Action("grantLoan", "", 0, null, null, 0),
-            new Action("grantLoan", "", 1, null, null, 0),
-            new Action("grantLoan", "", 2, null, null, 0),
-            new Action("grantLoan", "", 3, null, null, 0),
-            new Action("error", "", 0, null, null, 0))));
+            new Action(stateExecution.name(), "createCreditApplication", "", 0, null, null, 0),
+            new Action(stateExecution.name(), "acceptCreditApplication", "", 0, null, null, 0), // probably not the way to show manual action in future
+            new Action(stateExecution.name(), "grantLoan", "", 0, null, null, 0),
+            new Action(stateExecution.name(), "grantLoan", "", 0, null, null, 0),
+            new Action(stateExecution.name(), "grantLoan", "", 1, null, null, 0),
+            new Action(stateExecution.name(), "grantLoan", "", 2, null, null, 0),
+            new Action(stateExecution.name(), "grantLoan", "", 3, null, null, 0),
+            new Action(stateExecution.name(), "error", "", 0, null, null, 0))));
   }
 
 }

--- a/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/PreviewCreditApplicationWorkflowTest.java
+++ b/nflow-tests/src/test/java/com/nitorcreations/nflow/tests/PreviewCreditApplicationWorkflowTest.java
@@ -1,5 +1,6 @@
 package com.nitorcreations.nflow.tests;
 
+import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.stateExecution;
 import static java.util.Arrays.asList;
 import static org.apache.cxf.jaxrs.client.WebClient.fromClient;
 import static org.hamcrest.Matchers.notNullValue;
@@ -78,12 +79,12 @@ public class PreviewCreditApplicationWorkflowTest extends AbstractNflowTest {
   @Test
   public void t05_checkWorkflowInstanceActions() {
     assertWorkflowInstance(resp.id, actionHistoryValidator(asList(
-            new Action("previewCreditApplication", "", 0, null, null, 0),
-            new Action("acceptCreditApplication", "", 0, null, null, 0), // probably not the way to show manual action in future
-            new Action("grantLoan", "", 0, null, null, 0),
-            new Action("grantLoan", "", 0, null, null, 0),
-            new Action("finishCreditApplication", "", 0, null, null, 0),
-            new Action("done", "", 0, null, null, 0))));
+            new Action(stateExecution.name(), "previewCreditApplication", "", 0, null, null, 0),
+            new Action(stateExecution.name(), "acceptCreditApplication", "", 0, null, null, 0), // probably not the way to show manual action in future
+            new Action(stateExecution.name(), "grantLoan", "", 0, null, null, 0),
+            new Action(stateExecution.name(), "grantLoan", "", 0, null, null, 0),
+            new Action(stateExecution.name(), "finishCreditApplication", "", 0, null, null, 0),
+            new Action(stateExecution.name(), "done", "", 0, null, null, 0))));
   }
 
 }


### PR DESCRIPTION
Following types are supported currently:
- stateExecution - for actions created with normal execution. This is also set for old actions created before this feature.
- stateExecutionFailed - for actions that failed due throws exception or retry count was exceeded.
- externalChange - for state changes created manually via API.
- recovery - to indicate workflow was recovered after executor died.