### PR TITLE
update deps

### DIFF
--- a/nflow-metrics/pom.xml
+++ b/nflow-metrics/pom.xml
@@ -10,14 +10,12 @@
   <name>nflow-metrics</name>
   <description>Integrate http://metrics.dropwizard.io/ with nFlow</description>
   <properties>
-  	<metrics.version>3.1.0</metrics.version>
   </properties>
   <dependencies>
-  	<dependency>
-		<groupId>io.dropwizard.metrics</groupId>
-		<artifactId>metrics-core</artifactId>
-		<version>${metrics.version}</version>
-  	</dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.nitorcreations</groupId>
       <artifactId>nflow-engine</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
   </modules>
   <properties>
     <jdk.version>1.7</jdk.version>
-    <apache.cxf.version>3.0.3</apache.cxf.version>
+    <apache.cxf.version>3.0.4</apache.cxf.version>
     <commons.lang.version>2.6</commons.lang.version>
     <commons.lang3.version>3.3.2</commons.lang3.version>
     <core-utils.version>1.4</core-utils.version>
@@ -93,21 +93,21 @@
     <el.version>3.0.0</el.version>
     <findbugs-annotations.version>3.0.0</findbugs-annotations.version>
     <findbugs.version>3.0.0</findbugs.version>
-    <h2.version>1.4.185</h2.version>
+    <h2.version>1.4.186</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
-    <hikaricp.version>2.3.2</hikaricp.version>
-    <jackson.version>2.5.0</jackson.version>
+    <hikaricp.version>2.3.3</hikaricp.version>
+    <jackson.version>2.5.1</jackson.version>
     <javassist.version>3.19.0-GA</javassist.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
-    <jetty.version>9.2.7.v20150116</jetty.version>
+    <jetty.version>9.2.9.v20150224</jetty.version>
     <jodatime.version>2.7</jodatime.version>
     <junit.version>4.12</junit.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <logback-classic.version>1.1.2</logback-classic.version>
     <maven-clean.version>2.6.1</maven-clean.version>
-    <maven-cobertura.version>2.6</maven-cobertura.version>
+    <maven-cobertura.version>2.7</maven-cobertura.version>
     <maven-compiler.version>3.2</maven-compiler.version>
     <maven-dependency.version>2.10</maven-dependency.version>
     <maven-deploy.version>2.8.2</maven-deploy.version>
@@ -117,7 +117,7 @@
     <maven-findbugs.version>3.0.0</maven-findbugs.version>
     <maven-gpg.version>1.6</maven-gpg.version>
     <maven-install.version>2.5.2</maven-install.version>
-    <maven-jar.version>2.5</maven-jar.version>
+    <maven-jar.version>2.6</maven-jar.version>
     <maven-javadoc.version>2.10.1</maven-javadoc.version>
     <maven-jxr.version>2.5</maven-jxr.version>
     <maven-pmd.version>3.4</maven-pmd.version>
@@ -127,7 +127,8 @@
     <maven-site.version>3.4</maven-site.version>
     <maven-source.version>2.4</maven-source.version>
     <maven-surefire.version>2.18.1</maven-surefire.version>
-    <maven-swagger.version>2.3.2</maven-swagger.version>
+    <maven-swagger.version>2.3.3</maven-swagger.version>
+    <metrics.version>3.1.0</metrics.version>
     <mockito.version>1.10.19</mockito.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>5.1.34</mysql.version>
@@ -137,7 +138,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <slf4j.version>1.7.10</slf4j.version>
-    <spring.version>4.1.4.RELEASE</spring.version>
+    <spring.version>4.1.5.RELEASE</spring.version>
     <swagger.version>1.3.12</swagger.version>
     <validation.api.version>1.1.0.Final</validation.api.version>
     <versions-maven-plugin.version>2.1</versions-maven-plugin.version>
@@ -577,6 +578,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons.lang3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${metrics.version}</version>
       </dependency>
       <!-- specify commons-lang as runtime since we do not want any new code to depend on it -->
       <dependency>


### PR DESCRIPTION
- apache cxf 3.0.4: http://cxf.apache.org/cxf-304-release-notes.html
- h2 1.4.186: http://www.h2database.com/html/changelog.html
- hikaricp 2.3.3: https://github.com/brettwooldridge/HikariCP/blob/2.3.x/CHANGES
- jackson 2.5.1: https://github.com/FasterXML/jackson-core/blob/master/release-notes/VERSION
- jetty 9.2.9: https://github.com/eclipse/jetty.project/blob/master/VERSION.txt
- maven-cobertura-plugin 2.7: http://mojo.codehaus.org/cobertura-maven-plugin/index.html
- maven-jar-plugin 2.6: http://mail-archives.apache.org/mod_mbox/maven-announce/201503.mbox/%3C20150310103739.55BAD174B2@minotaur.apache.org%3E
- maven-swagger-plugin 2.3.3: https://github.com/kongchen/swagger-maven-plugin
- spring 4.1.5: https://jira.spring.io/secure/ReleaseNote.jspa?projectId=10000&version=14861