### PR TITLE
Update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,23 +89,23 @@
     <commons.lang.version>2.6</commons.lang.version>
     <commons.lang3.version>3.3.2</commons.lang3.version>
     <core-utils.version>1.4</core-utils.version>
-    <coveralls.version>3.0.1</coveralls.version>
+    <coveralls.version>3.1.0</coveralls.version>
     <el.version>3.0.0</el.version>
     <findbugs-annotations.version>3.0.0</findbugs-annotations.version>
     <findbugs.version>3.0.0</findbugs.version>
     <h2.version>1.4.186</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
-    <hikaricp.version>2.3.3</hikaricp.version>
+    <hikaricp.version>2.3.5</hikaricp.version>
     <jackson.version>2.5.1</jackson.version>
     <javassist.version>3.19.0-GA</javassist.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
-    <jetty.version>9.2.9.v20150224</jetty.version>
+    <jetty.version>9.2.10.v20150310</jetty.version>
     <jodatime.version>2.7</jodatime.version>
     <junit.version>4.12</junit.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-    <logback-classic.version>1.1.2</logback-classic.version>
+    <logback-classic.version>1.1.3</logback-classic.version>
     <maven-clean.version>2.6.1</maven-clean.version>
     <maven-cobertura.version>2.7</maven-cobertura.version>
     <maven-compiler.version>3.2</maven-compiler.version>
@@ -114,11 +114,11 @@
     <maven-download.version>1.2.1</maven-download.version>
     <maven-eclipse.version>2.9</maven-eclipse.version>
     <maven-enforcer.version>1.4</maven-enforcer.version>
-    <maven-findbugs.version>3.0.0</maven-findbugs.version>
+    <maven-findbugs.version>3.0.1</maven-findbugs.version>
     <maven-gpg.version>1.6</maven-gpg.version>
     <maven-install.version>2.5.2</maven-install.version>
     <maven-jar.version>2.6</maven-jar.version>
-    <maven-javadoc.version>2.10.1</maven-javadoc.version>
+    <maven-javadoc.version>2.10.2</maven-javadoc.version>
     <maven-jxr.version>2.5</maven-jxr.version>
     <maven-pmd.version>3.4</maven-pmd.version>
     <maven-project-info.version>2.8</maven-project-info.version>
@@ -127,18 +127,18 @@
     <maven-site.version>3.4</maven-site.version>
     <maven-source.version>2.4</maven-source.version>
     <maven-surefire.version>2.18.1</maven-surefire.version>
-    <maven-swagger.version>2.3.3</maven-swagger.version>
-    <metrics.version>3.1.0</metrics.version>
+    <maven-swagger.version>2.3.4</maven-swagger.version>
+    <metrics.version>3.1.1</metrics.version>
     <mockito.version>1.10.19</mockito.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
-    <mysql.version>5.1.34</mysql.version>
+    <mysql.version>5.1.35</mysql.version>
     <nexus-staging-maven.version>1.6.5</nexus-staging-maven.version>
     <nitor-matchers.version>1.3</nitor-matchers.version>
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <slf4j.version>1.7.10</slf4j.version>
-    <spring.version>4.1.5.RELEASE</spring.version>
+    <spring.version>4.1.6.RELEASE</spring.version>
     <swagger.version>1.3.12</swagger.version>
     <validation.api.version>1.1.0.Final</validation.api.version>
     <versions-maven-plugin.version>2.1</versions-maven-plugin.version>


### PR DESCRIPTION
coveralls              3.0.1 ->  3.1.0: https://github.com/trautonen/coveralls-maven-plugin/blob/master/CHANGELOG.md
hikaricp               2.3.3 ->  2.3.5: https://github.com/brettwooldridge/HikariCP/blob/3355525e9aa311564270e66ba2cfa5bcbad74e52/CHANGES
jetty                  9.2.9 -> 9.2.10: https://github.com/eclipse/jetty.project/blob/21f6bb6edf4521486ce9ebd86f57ee1b6ea306db/VERSION.txt
logback-classic        1.1.2 ->  1.1.3: http://logback.qos.ch/news.html
metrics                3.1.0 ->  3.1.1: https://github.com/dropwizard/metrics/issues?q=milestone%3A3.1.1+is%3Aclosed
mysql                 3.1.34 -> 3.1.35: http://dev.mysql.com/doc/relnotes/connector-j/en/news-5-1-35.html
spring                 4.1.5 ->  4.1.6: https://jira.spring.io/secure/ReleaseNote.jspa?projectId=10000&version=14863
findbugs-maven-plugin  3.0.0 ->  3.0.1: http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=11701&version=20667
javadoc-maven-plugin  2.10.1 -> 2.10.2: http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=11138&version=19347
maven-swagger-plugin   2.3.3 ->  2.3.4: https://github.com/kongchen/swagger-maven-plugin/commits/master