### PR TITLE
Workaroud eclipse bug/misfeature

### DIFF
--- a/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/service/SpringDummyTestWorkflow.java
+++ b/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/service/SpringDummyTestWorkflow.java
@@ -2,6 +2,7 @@ package com.nitorcreations.nflow.engine.service;
 
 import static com.nitorcreations.nflow.engine.workflow.definition.NextAction.moveToState;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.nitorcreations.nflow.engine.workflow.definition.NextAction;
@@ -10,6 +11,7 @@ import com.nitorcreations.nflow.engine.workflow.definition.WorkflowDefinition;
 import com.nitorcreations.nflow.engine.workflow.definition.WorkflowStateType;
 
 @Component
+@Profile("nflow-engine-test")
 public class SpringDummyTestWorkflow extends WorkflowDefinition<SpringDummyTestWorkflow.SpringDummyTestState> {
 
   public static enum SpringDummyTestState implements com.nitorcreations.nflow.engine.workflow.definition.WorkflowState {

--- a/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
+++ b/nflow-engine/src/test/java/com/nitorcreations/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
@@ -31,12 +31,12 @@ import com.nitorcreations.nflow.engine.workflow.definition.WorkflowDefinition;
 import com.nitorcreations.nflow.engine.workflow.definition.WorkflowState;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles("nflow-engine-test")
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class)
 public class WorkflowDefinitionServiceWithSpringTest {
 
   @Configuration
-  @Profile("test")
+  @Profile("nflow-engine-test")
   @ComponentScan(basePackageClasses = SpringDummyTestWorkflow.class)
   static class ContextConfiguration {
     @Bean


### PR DESCRIPTION
Eclipse includes the test code from included projects in the runtime of other projects. Use spring profiles to exclude some test workflows from autoscan.