### PR TITLE
Updated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,19 +86,19 @@
   </modules>
   <properties>
     <jdk.version>1.7</jdk.version>
-    <apache.cxf.version>3.0.4</apache.cxf.version>
+    <apache.cxf.version>3.1.0</apache.cxf.version>
     <commons.lang.version>2.6</commons.lang.version>
-    <commons.lang3.version>3.3.2</commons.lang3.version>
+    <commons.lang3.version>3.4</commons.lang3.version>
     <core-utils.version>1.4</core-utils.version>
     <coveralls.version>3.1.0</coveralls.version>
     <el.version>3.0.0</el.version>
     <findbugs-annotations.version>3.0.0</findbugs-annotations.version>
     <findbugs.version>3.0.0</findbugs.version>
-    <h2.version>1.4.186</h2.version>
+    <h2.version>1.4.187</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
-    <hikaricp.version>2.3.5</hikaricp.version>
-    <jackson.version>2.5.1</jackson.version>
+    <hikaricp.version>2.3.8</hikaricp.version>
+    <jackson.version>2.5.3</jackson.version>
     <javassist.version>3.19.0-GA</javassist.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
@@ -109,7 +109,7 @@
     <logback-classic.version>1.1.3</logback-classic.version>
     <maven-clean.version>2.6.1</maven-clean.version>
     <maven-cobertura.version>2.7</maven-cobertura.version>
-    <maven-compiler.version>3.2</maven-compiler.version>
+    <maven-compiler.version>3.3</maven-compiler.version>
     <maven-dependency.version>2.10</maven-dependency.version>
     <maven-deploy.version>2.8.2</maven-deploy.version>
     <maven-download.version>1.2.1</maven-download.version>
@@ -119,18 +119,18 @@
     <maven-gpg.version>1.6</maven-gpg.version>
     <maven-install.version>2.5.2</maven-install.version>
     <maven-jar.version>2.6</maven-jar.version>
-    <maven-javadoc.version>2.10.2</maven-javadoc.version>
+    <maven-javadoc.version>2.10.3</maven-javadoc.version>
     <maven-jxr.version>2.5</maven-jxr.version>
     <maven-pmd.version>3.4</maven-pmd.version>
     <maven-project-info.version>2.8</maven-project-info.version>
-    <maven-release.version>2.5.1</maven-release.version>
+    <maven-release.version>2.5.2</maven-release.version>
     <maven-resources.version>2.7</maven-resources.version>
     <maven-shade.version>2.3</maven-shade.version>
     <maven-site.version>3.4</maven-site.version>
     <maven-source.version>2.4</maven-source.version>
     <maven-surefire.version>2.18.1</maven-surefire.version>
     <maven-swagger.version>2.3.4</maven-swagger.version>
-    <metrics.version>3.1.1</metrics.version>
+    <metrics.version>3.1.2</metrics.version>
     <mockito.version>1.10.19</mockito.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>5.1.35</mysql.version>
@@ -139,11 +139,11 @@
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <slf4j.version>1.7.10</slf4j.version>
+    <slf4j.version>1.7.12</slf4j.version>
     <spring.version>4.1.6.RELEASE</spring.version>
     <swagger.version>1.3.12</swagger.version>
     <validation.api.version>1.1.0.Final</validation.api.version>
-    <versions-maven-plugin.version>2.1</versions-maven-plugin.version>
+    <versions-maven-plugin.version>2.2</versions-maven-plugin.version>
   </properties>
   <build>
     <pluginManagement>


### PR DESCRIPTION
Updated code dependencies:
cxf           3.0.4 -> 3.1.0    http://cxf.apache.org/docs/31-migration-guide.html
commons-lang3 3.3.2 -> 3.4      https://dist.apache.org/repos/dist/release/commons/lang/RELEASE-NOTES.txt
h2          1.4.186 -> 1.4.187  http://www.h2database.com/html/changelog.html
hikaricp      2.3.5 -> 2.3.7    https://github.com/brettwooldridge/HikariCP/blob/2.3.x/CHANGES
jackson       2.5.1 -> 2.5.3    https://github.com/FasterXML/jackson-core/blob/2.5/release-notes/VERSION
metrics       3.1.1 -> 3.1.2    https://github.com/dropwizard/metrics/commits/3.1-maintenance
slf4j        1.7.10 -> 1.7.12   http://www.slf4j.org/news.html

Updated maven plugins:
compiler        3.2 -> 3.3      http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=11130&version=20684
javadoc      2.10.2 -> 2.10.3   https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317529&version=12330876
release       2.5.1 -> 2.5.2    https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317824&version=12331215
versions        2.1 -> 2.2      http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=11830&version=21128