### PR TITLE
Update dependencies

### DIFF
--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/ExecutorDao.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/ExecutorDao.java
@@ -2,7 +2,6 @@ package com.nitorcreations.nflow.engine.internal.dao;
 
 import static com.nitorcreations.nflow.engine.internal.dao.DaoUtil.firstColumnLengthExtractor;
 import static com.nitorcreations.nflow.engine.internal.dao.DaoUtil.toDateTime;
-import static com.nitorcreations.nflow.engine.internal.storage.db.DatabaseConfiguration.NFLOW_DATABASE_INITIALIZER;
 import static com.nitorcreations.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.recovery;
 import static java.net.InetAddress.getLocalHost;
 import static org.apache.commons.lang3.StringUtils.left;
@@ -21,7 +20,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.joda.time.DateTime;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementCreator;
@@ -44,7 +42,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * used in some legacy systems.
  */
 @Component
-@DependsOn(NFLOW_DATABASE_INITIALIZER)
 public class ExecutorDao {
   private JdbcTemplate jdbc;
   SQLVariants sqlVariants;

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/StatisticsDao.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/dao/StatisticsDao.java
@@ -1,6 +1,5 @@
 package com.nitorcreations.nflow.engine.internal.dao;
 
-import static com.nitorcreations.nflow.engine.internal.storage.db.DatabaseConfiguration.NFLOW_DATABASE_INITIALIZER;
 import static java.util.Arrays.asList;
 
 import java.sql.ResultSet;
@@ -14,7 +13,6 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.joda.time.DateTime;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
@@ -31,7 +29,6 @@ import com.nitorcreations.nflow.engine.workflow.statistics.Statistics.QueueStati
  * used in some legacy systems.
  */
 @Component
-@DependsOn(NFLOW_DATABASE_INITIALIZER)
 public class StatisticsDao {
 
   private JdbcTemplate jdbc;

--- a/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/com/nitorcreations/nflow/engine/internal/storage/db/DatabaseConfiguration.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -21,7 +22,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 public abstract class DatabaseConfiguration {
-  public static final String NFLOW_DATABASE_INITIALIZER = "nflowDatabaseInitializer";
+  private static final String NFLOW_DATABASE_INITIALIZER = "nflowDatabaseInitializer";
   private static final Logger logger = getLogger(DatabaseConfiguration.class);
   private final String dbType;
 
@@ -62,6 +63,7 @@ public abstract class DatabaseConfiguration {
   @Bean
   @NFlow
   @Scope(SCOPE_PROTOTYPE)
+  @DependsOn(NFLOW_DATABASE_INITIALIZER)
   public JdbcTemplate nflowJdbcTemplate(@NFlow DataSource nflowDataSource) {
     return new JdbcTemplate(nflowDataSource);
   }
@@ -69,6 +71,7 @@ public abstract class DatabaseConfiguration {
   @Bean
   @NFlow
   @Scope(SCOPE_PROTOTYPE)
+  @DependsOn(NFLOW_DATABASE_INITIALIZER)
   public NamedParameterJdbcTemplate nflowNamedParameterJdbcTemplate(@NFlow DataSource nflowDataSource) {
     return new NamedParameterJdbcTemplate(nflowDataSource);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
   </modules>
   <properties>
     <jdk.version>1.7</jdk.version>
-    <apache.cxf.version>3.1.0</apache.cxf.version>
+    <apache.cxf.version>3.1.2</apache.cxf.version>
     <commons.lang.version>2.6</commons.lang.version>
     <commons.lang3.version>3.4</commons.lang3.version>
     <core-utils.version>1.4</core-utils.version>
@@ -94,16 +94,16 @@
     <el.version>3.0.0</el.version>
     <findbugs-annotations.version>3.0.0</findbugs-annotations.version>
     <findbugs.version>3.0.0</findbugs.version>
-    <h2.version>1.4.187</h2.version>
+    <h2.version>1.4.188</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <hibernate.validator.version>5.1.3.Final</hibernate.validator.version>
-    <hikaricp.version>2.3.8</hikaricp.version>
-    <jackson.version>2.5.3</jackson.version>
-    <javassist.version>3.19.0-GA</javassist.version>
+    <hibernate.validator.version>5.2.1.Final</hibernate.validator.version>
+    <hikaricp.version>2.3.9</hikaricp.version>
+    <jackson.version>2.6.1</jackson.version>
+    <javassist.version>3.20.0-GA</javassist.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
-    <jetty.version>9.2.10.v20150310</jetty.version>
-    <jodatime.version>2.7</jodatime.version>
+    <jetty.version>9.2.13.v20150730</jetty.version>
+    <jodatime.version>2.8.2</jodatime.version>
     <junit.version>4.12</junit.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <logback-classic.version>1.1.3</logback-classic.version>
@@ -113,7 +113,7 @@
     <maven-dependency.version>2.10</maven-dependency.version>
     <maven-deploy.version>2.8.2</maven-deploy.version>
     <maven-download.version>1.2.1</maven-download.version>
-    <maven-eclipse.version>2.9</maven-eclipse.version>
+    <maven-eclipse.version>2.10</maven-eclipse.version>
     <maven-enforcer.version>1.4</maven-enforcer.version>
     <maven-findbugs.version>3.0.1</maven-findbugs.version>
     <maven-gpg.version>1.6</maven-gpg.version>
@@ -121,11 +121,11 @@
     <maven-jar.version>2.6</maven-jar.version>
     <maven-javadoc.version>2.10.3</maven-javadoc.version>
     <maven-jxr.version>2.5</maven-jxr.version>
-    <maven-pmd.version>3.4</maven-pmd.version>
+    <maven-pmd.version>3.5</maven-pmd.version>
     <maven-project-info.version>2.8</maven-project-info.version>
     <maven-release.version>2.5.2</maven-release.version>
     <maven-resources.version>2.7</maven-resources.version>
-    <maven-shade.version>2.3</maven-shade.version>
+    <maven-shade.version>2.4.1</maven-shade.version>
     <maven-site.version>3.4</maven-site.version>
     <maven-source.version>2.4</maven-source.version>
     <maven-surefire.version>2.18.1</maven-surefire.version>
@@ -133,15 +133,15 @@
     <metrics.version>3.1.2</metrics.version>
     <mockito.version>1.10.19</mockito.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
-    <mysql.version>5.1.35</mysql.version>
-    <nexus-staging-maven.version>1.6.5</nexus-staging-maven.version>
+    <mysql.version>5.1.36</mysql.version>
+    <nexus-staging-maven.version>1.6.6</nexus-staging-maven.version>
     <nitor-matchers.version>1.3</nitor-matchers.version>
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <slf4j.version>1.7.12</slf4j.version>
-    <spring.version>4.1.6.RELEASE</spring.version>
-    <swagger.version>1.5.0</swagger.version>
+    <spring.version>4.2.0.RELEASE</spring.version>
+    <swagger.version>1.5.3</swagger.version>
     <validation.api.version>1.1.0.Final</validation.api.version>
     <versions-maven-plugin.version>2.2</versions-maven-plugin.version>
   </properties>


### PR DESCRIPTION
Jackson 2.6.0: https://github.com/FasterXML/jackson-core/blob/master/release-notes/VERSION
HikariCP 2.3.9: https://github.com/brettwooldridge/HikariCP/blob/2.3.x/CHANGES
Jodatime 2.8.1: https://github.com/JodaOrg/joda-time/blob/master/RELEASE-NOTES.txt
MySQL Connector/J 5.1.36: http://dev.mysql.com/doc/relnotes/connector-j/en/news-5-1-36.html
Apache CXF 3.1.1: http://cxf.apache.org/docs/31-migration-guide.html
Jetty 9.2.12: https://github.com/eclipse/jetty.project/blob/master/VERSION.txt
Hibernate-validator 5.2.0: https://github.com/hibernate/hibernate-validator/blob/master/changelog.txt
Java-assist 3.20.0: https://github.com/jboss-javassist/javassist/releases/tag/rel_3_20_0_ga
Spring 4.1.7: https://jira.spring.io/jira/secure/ReleaseNote.jspa?projectId=10000&version=14936
maven-eclipse-plugin 2.10: http://blog.soebes.de/blog/2015/05/28/apache-maven-eclipse-plugin-version-2-dot-10-released/