### PR TITLE
Fix CORS preflight handling for /v1/workflow-instance

### DIFF
--- a/nflow-rest-api/src/main/java/io/nflow/rest/v1/WorkflowInstanceResource.java
+++ b/nflow-rest-api/src/main/java/io/nflow/rest/v1/WorkflowInstanceResource.java
@@ -8,6 +8,7 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.WILDCARD;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.status;
@@ -37,11 +38,13 @@ import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.OPTIONS;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -103,6 +106,14 @@ public class WorkflowInstanceResource {
     this.createWorkflowConverter = createWorkflowConverter;
     this.listWorkflowConverter = listWorkflowConverter;
     this.workflowInstanceFactory = workflowInstanceFactory;
+  }
+
+  @OPTIONS
+  @Path("{any: .*}")
+  @ApiOperation(value = "CORS preflight handling")
+  @Consumes(WILDCARD)
+  public Response corsPreflight() {
+    return Response.ok().build();
   }
 
   @PUT


### PR DESCRIPTION
nFlow ```CorsHeaderContainerResponseFilter``` does not currently process CORS preflight (```OPTIONS```) so workflow instances cannot be updated when nFlow Explorer is served from different URL than nFlow REST API.

This is because there're not resources behind the filter that could be called through ```CorsHeaderContainerResponseFilter```. This PR implements a dummy ```OPTIONS``` service.

The fix can be tested e.g. by running nFlow Explorer locally in port 9000 (```grunt serve```) and starting nFlow test server to port 7500 (```java -jar nflow-tests/target/nflow-tests-4.2.1-SNAPSHOT.jar```). Without this fix workflow instances cannot be updated.