### PR TITLE
Properties for explicit DB column max lengths

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
@@ -54,7 +54,7 @@ public class ExecutorDao {
   String executorGroupCondition;
   int timeoutSeconds;
   int executorId = -1;
-  int hostMaxLength = -1;
+  int hostMaxLength;
 
   @Inject
   public void setEnvironment(Environment env) {
@@ -62,6 +62,8 @@ public class ExecutorDao {
     this.executorGroupCondition = createWhereCondition(executorGroup);
     timeoutSeconds = env.getRequiredProperty("nflow.executor.timeout.seconds", Integer.class);
     keepaliveIntervalSeconds = env.getRequiredProperty("nflow.executor.keepalive.seconds", Integer.class);
+    // In one deployment, FirstColumnLengthExtractor returned 0 column length (H2), so allow explicit length setting.
+    hostMaxLength = env.getProperty("nflow.executor.host.length", Integer.class, -1);
   }
 
   @Inject

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -98,8 +98,8 @@ public class WorkflowInstanceDao {
   private long workflowInstanceQueryMaxResultsDefault;
   private long workflowInstanceQueryMaxActions;
   private long workflowInstanceQueryMaxActionsDefault;
-  int instanceStateTextLength = -1;
-  int actionStateTextLength = -1;
+  int instanceStateTextLength;
+  int actionStateTextLength;
 
   @Inject
   public void setSqlVariants(SQLVariants sqlVariants) {
@@ -134,6 +134,9 @@ public class WorkflowInstanceDao {
     workflowInstanceQueryMaxActions = env.getRequiredProperty("nflow.workflow.instance.query.max.actions", Long.class);
     workflowInstanceQueryMaxActionsDefault = env.getRequiredProperty("nflow.workflow.instance.query.max.actions.default",
         Long.class);
+    // In one deployment, FirstColumnLengthExtractor returned 0 column length (H2), so allow explicit length setting.
+    instanceStateTextLength = env.getProperty("nflow.workflow.instance.state.text.length", Integer.class, -1);
+    actionStateTextLength = env.getProperty("nflow.workflow.action.state.text.length", Integer.class, -1);
   }
 
   @Inject


### PR DESCRIPTION
In one deployment (with Java 7 and nFlow 3.3.0), H2 strangely returned 0 as column length:
- https://github.com/NitorCreations/nflow/blob/4.0.0/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java#L139
- https://github.com/NitorCreations/nflow/blob/4.0.0/nflow-engine/src/main/java/io/nflow/engine/internal/dao/DaoUtil.java#L33

As a result, state transition failed (StringUtils.abbreviate() error "minimum abbreviation width 4").

The problem could not be reproduced in test deployment. This PR enables setting column lengths through properties, so that such problems can be at least evaded, if ever encountered again.