### PR TITLE
Upgrade to Spring 5.0.1.RELEASE with nflow 5.0.0-SNAPSHOT

### DIFF
--- a/nflow-engine/pom.xml
+++ b/nflow-engine/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/config/EngineConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/config/EngineConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
@@ -57,6 +58,6 @@ public class EngineConfiguration {
     if (filename != null) {
       return new ClassPathResource(filename);
     }
-    return null;
+    return new ByteArrayResource(new byte[0]);
   }
 }

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/config/EngineConfigurationTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/config/EngineConfigurationTest.java
@@ -55,7 +55,7 @@ public class EngineConfigurationTest {
   }
 
   @Test
-  public void nonSpringWorkflowsListingInstantiationAttempted() throws IOException {
+  public void nonSpringWorkflowsListingInstantiationAttempted() {
     environment.withProperty("nflow.non_spring_workflows_filename", "dummy");
     assertEquals(configuration.nflowNonSpringWorkflowsListing(environment).getFilename(), "dummy");
   }

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/config/EngineConfigurationTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/config/EngineConfigurationTest.java
@@ -2,10 +2,10 @@ package io.nflow.engine.internal.config;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
 import java.util.concurrent.ThreadFactory;
 
 import org.joda.time.DateTime;
@@ -50,14 +50,14 @@ public class EngineConfigurationTest {
   }
 
   @Test
-  public void nonSpringWorkflowsListingNotInstantiated() {
-    assertThat(configuration.nflowNonSpringWorkflowsListing(environment), nullValue());
+  public void nonSpringWorkflowsListingNotInstantiated() throws IOException {
+    assertEquals(configuration.nflowNonSpringWorkflowsListing(environment).contentLength(), 0L);
   }
 
   @Test
-  public void nonSpringWorkflowsListingInstantiationAttempted() {
+  public void nonSpringWorkflowsListingInstantiationAttempted() throws IOException {
     environment.withProperty("nflow.non_spring_workflows_filename", "dummy");
-    assertThat(configuration.nflowNonSpringWorkflowsListing(environment), notNullValue());
+    assertEquals(configuration.nflowNonSpringWorkflowsListing(environment).getFilename(), "dummy");
   }
 
   @Test

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
@@ -63,7 +63,7 @@ public class WorkflowDefinitionServiceWithSpringTest {
     @Bean
     @NFlow
     public AbstractResource nflowNonSpringWorkflowsListing() {
-      return null;
+      return mock(AbstractResource.class);
     }
 
     @Bean

--- a/nflow-jetty/pom.xml
+++ b/nflow-jetty/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/nflow-metrics/pom.xml
+++ b/nflow-metrics/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.nflow</groupId>
     <artifactId>nflow-root</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/nflow-perf-test/pom.xml
+++ b/nflow-perf-test/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.nflow</groupId>
     <artifactId>nflow-root</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/nflow-rest-api/pom.xml
+++ b/nflow-rest-api/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <EMPTY></EMPTY>

--- a/nflow-rest-api/src/test/java/io/nflow/rest/v1/config/RestConfigurationTest.java
+++ b/nflow-rest-api/src/test/java/io/nflow/rest/v1/config/RestConfigurationTest.java
@@ -26,6 +26,6 @@ public class RestConfigurationTest {
   @Test
   public void nflowRestObjectMapperInstantiated() {
     ObjectMapper restMapper = configuration.nflowRestObjectMapper(new ObjectMapper());
-    assertThat(restMapper.getSerializationConfig().hasMapperFeatures(WRITE_DATES_AS_TIMESTAMPS.getMask()), is(true));
+    assertThat(restMapper.getSerializationConfig().hasSerializationFeatures(WRITE_DATES_AS_TIMESTAMPS.getMask()), is(false));
   }
 }

--- a/nflow-tests/pom.xml
+++ b/nflow-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.nflow</groupId>
     <artifactId>nflow-root</artifactId>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>
@@ -36,7 +36,7 @@
       <artifactId>annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.github.robwin</groupId>
+      <groupId>io.github.swagger2markup</groupId>
       <artifactId>swagger2markup</artifactId>
     </dependency>
     <dependency>
@@ -72,6 +72,13 @@
       <artifactId>postgresql-embedded</artifactId>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <id>pentaho-repo</id>
+      <name>pentaho-repo</name>
+      <url>https://public.nexus.pentaho.org/content/groups/omni/</url>
+    </repository>
+  </repositories>
   <profiles>
     <profile>
       <id>oracle</id>

--- a/nflow-tests/src/test/java/io/nflow/tests/Swagger2MarkupTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/Swagger2MarkupTest.java
@@ -2,18 +2,20 @@ package io.nflow.tests;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
-import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import io.github.robwin.swagger2markup.Swagger2MarkupConverter;
+import io.github.swagger2markup.Swagger2MarkupConverter;
 import io.nflow.tests.runner.NflowServerRule;
 
 public class Swagger2MarkupTest extends AbstractNflowTest {
 
-  private static final String SWAGGER2_MARKUP_ASCIIDOC_DIR = "src/main/asciidoc/swagger2markup";
+  private static final Path SWAGGER2_MARKUP_ASCIIDOC_DIR = Paths.get("src/main/asciidoc/swagger2markup");
 
   @ClassRule
   public static NflowServerRule server = new NflowServerRule.Builder().build();
@@ -23,11 +25,12 @@ public class Swagger2MarkupTest extends AbstractNflowTest {
   }
 
   @Test
-  public void convertRemoteSwaggerToAsciiDoc() throws IOException {
-    Swagger2MarkupConverter.from(server.getHttpAddress() + "/api/swagger.json").build().intoFolder(SWAGGER2_MARKUP_ASCIIDOC_DIR);
+  public void convertRemoteSwaggerToAsciiDoc() throws MalformedURLException {
+    Swagger2MarkupConverter.from(new URL(server.getHttpAddress() + "/api/swagger.json")).build()
+        .toFolder(SWAGGER2_MARKUP_ASCIIDOC_DIR);
 
-    // Then validate that three AsciiDoc files have been created
-    String[] files = new File(SWAGGER2_MARKUP_ASCIIDOC_DIR).list();
-    assertEquals(4, files.length);
+    // Then validate that the right number of AsciiDoc files have been created
+    String[] files = SWAGGER2_MARKUP_ASCIIDOC_DIR.toFile().list();
+    assertEquals(5, files.length);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>nflow-root</artifactId>
   <packaging>pom</packaging>
   <description>nFlow Root</description>
-  <version>4.2.1-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <url>http://nflow.io</url>
   <licenses>
     <license>
@@ -99,10 +99,10 @@
     <findbugs.version>3.0.1</findbugs.version>
     <h2.version>1.4.196</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <hibernate.validator.version>5.4.1.Final</hibernate.validator.version>
+    <hibernate.validator.version>6.0.2.Final</hibernate.validator.version>
     <hikaricp.version>2.6.3</hikaricp.version>
-    <jackson.version>2.8.9</jackson.version>
-    <jackson-databind.version>2.8.9</jackson-databind.version>
+    <jackson.version>2.9.2</jackson.version>
+    <jackson-databind.version>2.9.2</jackson-databind.version>
     <javassist.version>3.21.0-GA</javassist.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
@@ -135,7 +135,7 @@
     <maven-site.version>3.6</maven-site.version>
     <maven-source.version>3.0.1</maven-source.version>
     <maven-surefire.version>2.20</maven-surefire.version>
-    <metrics.version>3.2.3</metrics.version>
+    <metrics.version>3.2.4</metrics.version>
     <mockito.version>2.2.29</mockito.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>5.1.42</mysql.version>
@@ -146,10 +146,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <slf4j.version>1.7.25</slf4j.version>
-    <spring.version>4.3.9.RELEASE</spring.version>
-    <swagger.version>1.5.10</swagger.version>
-    <swagger2markup.version>0.9.2</swagger2markup.version>
-    <validation.api.version>1.1.0.Final</validation.api.version>
+    <spring.version>5.0.1.RELEASE</spring.version>
+    <swagger.version>1.5.16</swagger.version>
+    <swagger2markup.version>1.3.1</swagger2markup.version>
+    <validation.api.version>2.0.0.Final</validation.api.version>
     <versions-maven-plugin.version>2.4</versions-maven-plugin.version>
   </properties>
   <build>
@@ -698,7 +698,7 @@
         <version>${swagger.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.github.robwin</groupId>
+        <groupId>io.github.swagger2markup</groupId>
         <artifactId>swagger2markup</artifactId>
         <version>${swagger2markup.version}</version>
         <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
       <email>edvard.fonsell@nitor.fi</email>
       <organization>Nitor Creations</organization>
     </developer>
+    <developer>
+      <name>Timo Tiuraniemi</name>
+      <email>timo.tiuraniemi@nitor.com</email>
+      <organization>Nitor Creations</organization>
+    </developer>
   </developers>
   <modules>
     <module>nflow-rest-api</module>


### PR DESCRIPTION
Upgrade nflow to newly released Spring 5.0.1.RELEASE. Because this is a backward incompatible change, also bump nFlow version to 5.0.0.

Also update dependency versions.

This is a first of three PR's that aim to bring netty/webflux support to nFlow.