### PR TITLE
Reorganize engine configuration packages

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/config/EngineConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/EngineConfiguration.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.config;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static java.lang.Runtime.getRuntime;
@@ -16,6 +16,7 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 
 @Configuration

--- a/nflow-engine/src/main/java/io/nflow/engine/config/EngineConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/EngineConfiguration.java
@@ -19,10 +19,20 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 
+/**
+ * The main Spring configuration class for nFlow engine.
+ */
 @Configuration
 @ComponentScan("io.nflow.engine")
 public class EngineConfiguration {
 
+  /**
+   * Creates a workflow instance executor for processing workflow instances.
+   *
+   * @param nflowThreadFactory Thread factory to be used for creating instance executor threads.
+   * @param env The Spring environment.
+   * @return Workflow instance executor.
+   */
   @Bean
   public WorkflowInstanceExecutor nflowExecutor(@NFlow ThreadFactory nflowThreadFactory, Environment env) {
     int threadCount = env.getProperty("nflow.executor.thread.count", Integer.class, 2 * getRuntime().availableProcessors());
@@ -34,6 +44,10 @@ public class EngineConfiguration {
         nflowThreadFactory);
   }
 
+  /**
+   * Creates a thread factory for creating instance executor threads.
+   * @return Instance executor thread factory.
+   */
   @Bean
   @NFlow
   public ThreadFactory nflowThreadFactory() {
@@ -42,6 +56,10 @@ public class EngineConfiguration {
     return factory;
   }
 
+  /**
+   * Creates an object mapper for serializing and deserializing workflow instance state variables to and from database.
+   * @return Object mapper.
+   */
   @Bean
   @NFlow
   public ObjectMapper nflowObjectMapper() {
@@ -51,6 +69,11 @@ public class EngineConfiguration {
     return mapper;
   }
 
+  /**
+   * Creates a resource for listing workflows that are not defined as Spring beans.
+   * @param env The Spring environment.
+   * @return A resource representing the file that contains a list of workflow class names.
+   */
   @Bean
   @NFlow
   public AbstractResource nflowNonSpringWorkflowsListing(Environment env) {

--- a/nflow-engine/src/main/java/io/nflow/engine/config/NFlow.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/NFlow.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.config;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;

--- a/nflow-engine/src/main/java/io/nflow/engine/config/NFlow.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/NFlow.java
@@ -11,6 +11,9 @@ import java.lang.annotation.Target;
 
 import javax.inject.Qualifier;
 
+/**
+ * Marker annotation for nFlow.
+ */
 @Target({ FIELD, PARAMETER, TYPE, METHOD })
 @Retention(RUNTIME)
 @Qualifier

--- a/nflow-engine/src/main/java/io/nflow/engine/config/Profiles.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/Profiles.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.config;
 
 public abstract class Profiles {
   public static final String H2 = "nflow.db.h2";

--- a/nflow-engine/src/main/java/io/nflow/engine/config/Profiles.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/Profiles.java
@@ -1,10 +1,38 @@
 package io.nflow.engine.config;
 
+/**
+ * Constants for profile names supported by nFlow.
+ */
 public abstract class Profiles {
+
+  /**
+   * Profile to enable H2 database.
+   */
   public static final String H2 = "nflow.db.h2";
+
+  /**
+   * Profile to enable MySQL database.
+   */
   public static final String MYSQL = "nflow.db.mysql";
+
+  /**
+   * Profile to enable Oracle database.
+   */
   public static final String ORACLE = "nflow.db.oracle";
+
+  /**
+   * Profile to enable PostgreSQL database.
+   */
   public static final String POSTGRESQL = "nflow.db.postgresql";
+
+  /**
+   * Profile to enable JMX services.
+   */
   public static final String JMX = "jmx";
+
+  /**
+   * Profile to enable Metrics.
+   */
   public static final String METRICS = "metrics";
+
 }

--- a/nflow-engine/src/main/java/io/nflow/engine/config/PropertiesConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/PropertiesConfiguration.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;

--- a/nflow-engine/src/main/java/io/nflow/engine/config/PropertiesConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/PropertiesConfiguration.java
@@ -3,6 +3,9 @@ package io.nflow.engine.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
+/**
+ * Spring configuration for including properties from nflow-engine.properties file.
+ */
 @Configuration
 @PropertySource("classpath:nflow-engine.properties")
 public class PropertiesConfiguration {

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.storage.db;
+package io.nflow.engine.config.db;
 
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -21,6 +21,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import io.nflow.engine.config.NFlow;
+import io.nflow.engine.internal.storage.db.DatabaseInitializer;
 
 public abstract class DatabaseConfiguration {
   public static final String NFLOW_DATABASE_INITIALIZER = "nflowDatabaseInitializer";

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
@@ -23,15 +23,34 @@ import com.zaxxer.hikari.HikariDataSource;
 import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.storage.db.DatabaseInitializer;
 
+/**
+ * Base class for different database configurations.
+ */
 public abstract class DatabaseConfiguration {
+
+  /**
+   * Name of the nFlow database initializer bean.
+   */
   public static final String NFLOW_DATABASE_INITIALIZER = "nflowDatabaseInitializer";
+
   private static final Logger logger = getLogger(DatabaseConfiguration.class);
+
   private final String dbType;
 
+  /**
+   * Creates a new configuration with given database type.
+   * @param dbType Defines the database creation script and configuration properties to be used.
+   */
   protected DatabaseConfiguration(String dbType) {
     this.dbType = dbType;
   }
 
+  /**
+   * Creates the datasource bean for nFlow.
+   * @param env The Spring environment for getting the configuration property values.
+   * @param appCtx The application context for searching Metrics registry bean.
+   * @return The datasource for nFlow.
+   */
   @Bean
   @NFlow
   public DataSource nflowDatasource(Environment env, BeanFactory appCtx) {
@@ -62,6 +81,11 @@ public abstract class DatabaseConfiguration {
     }
   }
 
+  /**
+   * Creates a JDBC template using nFlow datasource.
+   * @param nflowDataSource The nFlow datasource.
+   * @return A JDBC template.
+   */
   @Bean
   @NFlow
   @Scope(SCOPE_PROTOTYPE)
@@ -70,6 +94,11 @@ public abstract class DatabaseConfiguration {
     return new JdbcTemplate(nflowDataSource);
   }
 
+  /**
+   * Creates a named parameter JDBC template using nFlow datasource.
+   * @param nflowDataSource The nFlow datasource.
+   * @return A named parameter JDBC template.
+   */
   @Bean
   @NFlow
   @Scope(SCOPE_PROTOTYPE)
@@ -78,16 +107,35 @@ public abstract class DatabaseConfiguration {
     return new NamedParameterJdbcTemplate(nflowDataSource);
   }
 
+  /**
+   * Creates a transaction template.
+   * @param platformTransactionManager Transaction manager to be used.
+   * @return A transaction template.
+   */
   @Bean
   @NFlow
   public TransactionTemplate nflowTransactionTemplate(PlatformTransactionManager platformTransactionManager) {
     return new TransactionTemplate(platformTransactionManager);
   }
 
+  /**
+   * Get a database configuration string property from the environment, or if the generic property is not defined, the property
+   * based on the database type.
+   * @param env The Spring environment.
+   * @param key The property key.
+   * @return The property value.
+   */
   protected String property(Environment env, String key) {
     return property(env, key, String.class);
   }
 
+  /**
+   * Get the database configuration property of given type from the environment, or if the generic property is not defined, the
+   * property based on the database type.
+   * @param env The Spring environment.
+   * @param key The property key.
+   * @return The property value.
+   */
   protected <T> T property(Environment env, String key, Class<T> type) {
     T val = env.getProperty("nflow.db." + key, type);
     if (val == null) {
@@ -99,9 +147,16 @@ public abstract class DatabaseConfiguration {
     return val;
   }
 
+  /**
+   * Creates the nFlow database initializer.
+   * @param dataSource The nFlow datasource.
+   * @param env The Spring environment.
+   * @return The database initializer.
+   */
   @Bean(name = NFLOW_DATABASE_INITIALIZER)
   @NFlow
   public DatabaseInitializer nflowDatabaseInitializer(@NFlow DataSource dataSource, Environment env) {
     return new DatabaseInitializer(dbType, dataSource, env);
   }
+
 }

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/H2DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/H2DatabaseConfiguration.java
@@ -15,13 +15,26 @@ import org.springframework.core.env.Environment;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
+/**
+ * Configuration for H2 database.
+ */
 @Profile(H2)
 @Configuration
 public class H2DatabaseConfiguration extends DatabaseConfiguration {
+
+  /**
+   * Create a new instance.
+   */
   public H2DatabaseConfiguration() {
     super("h2");
   }
 
+  /**
+   * Creates a server for connecting to the in-memory database.
+   * @param env The Spring environemnt for getting the configuration properties.
+   * @return A TCP server.
+   * @throws SQLException
+   */
   @Bean(initMethod="start", destroyMethod="stop")
   Server h2TcpServer(Environment env) throws SQLException {
     String port = env.getProperty("nflow.db.h2.tcp.port");
@@ -31,6 +44,12 @@ public class H2DatabaseConfiguration extends DatabaseConfiguration {
     return Server.createTcpServer("-tcp","-tcpAllowOthers","-tcpPort",port);
   }
 
+  /**
+   * Creates a console server for connecting to the in-memory database.
+   * @param env The Spring environemnt for getting the configuration properties.
+   * @return A TCP server.
+   * @throws SQLException
+   */
   @Bean(initMethod="start", destroyMethod="stop")
   Server h2ConsoleServer(Environment env) throws SQLException {
     String port = env.getProperty("nflow.db.h2.console.port");
@@ -40,27 +59,47 @@ public class H2DatabaseConfiguration extends DatabaseConfiguration {
     return Server.createTcpServer("-webPort",port);
   }
 
+  /**
+   * Creates the SQL variants for H2 database.
+   * @return SQL variants optimized for H2.
+   */
   @Bean
   public SQLVariants sqlVariants() {
     return new H2SQLVariants();
   }
 
+  /**
+   * SQL variants optimized for H2.
+   */
   public static class H2SQLVariants implements SQLVariants {
+
+    /**
+     * Returns SQL representing the current database time plus given amount of seconds.
+     */
     @Override
     public String currentTimePlusSeconds(int seconds) {
       return "dateadd('second', " + seconds + ", current_timestamp)";
     }
 
+    /**
+     * Returns false as H2 does not support update returning clause.
+     */
     @Override
     public boolean hasUpdateReturning() {
       return false;
     }
 
+    /**
+     * Returns false as H2 does not support updateable CTEs.
+     */
     @Override
     public boolean hasUpdateableCTE() {
       return false;
     }
 
+    /**
+     * Returns SQL representing the next activation time of the workflow instance.
+     */
     @Override
     public String nextActivationUpdate() {
       return "(case "
@@ -69,36 +108,57 @@ public class H2DatabaseConfiguration extends DatabaseConfiguration {
           + "else least(?, external_next_activation) end)";
     }
 
+    /**
+     * Returns the SQL representation for given workflow instance status.
+     */
     @Override
     public String workflowStatus(WorkflowInstanceStatus status) {
       return "'" + status.name() + "'";
     }
 
+    /**
+     * Returns SQL representing the workflow instance status parameter.
+     */
     @Override
     public String workflowStatus() {
       return "?";
     }
 
+    /**
+     * Returns SQL representing the action type parameter.
+     */
     @Override
     public String actionType() {
       return "?";
     }
 
+    /**
+     * Returns empty string as casting to text is not needed in H2.
+     */
     @Override
     public String castToText() {
       return "";
     }
 
+    /**
+     * Returns SQL for a query with a limit of results.
+     */
     @Override
     public String limit(String query, String limit) {
       return query + " limit " + limit;
     }
 
+    /**
+     * Returns the SQL type for long text.
+     */
     @Override
     public int longTextType() {
       return Types.VARCHAR;
     }
 
+    /**
+     * Returns true as H2 suppports batch updates.
+     */
     @Override
     public boolean useBatchUpdate() {
       return true;

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/H2DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/H2DatabaseConfiguration.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.storage.db;
+package io.nflow.engine.config.db;
 
 import static io.nflow.engine.config.Profiles.H2;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 
+import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
 @Profile(H2)

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/MysqlDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/MysqlDatabaseConfiguration.java
@@ -25,15 +25,27 @@ import io.nflow.engine.internal.storage.db.DatabaseInitializer;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
+/**
+ * Configuration for MySQL database.
+ */
 @Profile(MYSQL)
 @Configuration
 public class MysqlDatabaseConfiguration extends DatabaseConfiguration {
   private static final Logger logger = getLogger(MysqlDatabaseConfiguration.class);
 
+  /**
+   * Create a new instance.
+   */
   public MysqlDatabaseConfiguration() {
     super("mysql");
   }
 
+  /**
+   * Creates the nFlow database initializer. Selects correct database creation script based on database version.
+   * @param dataSource The nFlow datasource.
+   * @param env The Spring environment.
+   * @return The database initializer.
+   */
   @Bean
   @Override
   @SuppressFBWarnings(value = { "CLI_CONSTANT_LIST_INDEX", "WEM_WEAK_EXCEPTION_MESSAGING" }, //
@@ -63,27 +75,47 @@ public class MysqlDatabaseConfiguration extends DatabaseConfiguration {
     return new DatabaseInitializer(dbType, nflowDataSource, env);
   }
 
+  /**
+   * Creates the SQL variants for MySQL database.
+   * @return SQL variants optimized for MySQL.
+   */
   @Bean
   public SQLVariants sqlVariants() {
     return new MySQLVariants();
   }
 
+  /**
+   * SQL variants optimized for MySQL.
+   */
   public static class MySQLVariants implements SQLVariants {
+
+    /**
+     * Returns SQL representing the current database time plus given amount of seconds.
+     */
     @Override
     public String currentTimePlusSeconds(int seconds) {
       return "from_unixtime(unix_timestamp() + " + seconds + ")";
     }
 
+    /**
+     * Returns false as MySQL does not support update returning clause.
+     */
     @Override
     public boolean hasUpdateReturning() {
       return false;
     }
 
+    /**
+     * Returns false as MySQL does not support updateable CTEs.
+     */
     @Override
     public boolean hasUpdateableCTE() {
       return false;
     }
 
+    /**
+     * Returns SQL representing the next activation time of the workflow instance.
+     */
     @Override
     public String nextActivationUpdate() {
       return "(case "
@@ -92,36 +124,57 @@ public class MysqlDatabaseConfiguration extends DatabaseConfiguration {
           + "else least(?, external_next_activation) end)";
     }
 
+    /**
+     * Returns the SQL representation for given workflow instance status.
+     */
     @Override
     public String workflowStatus(WorkflowInstanceStatus status) {
       return "'" + status.name() + "'";
     }
 
+    /**
+     * Returns SQL representing the workflow instance status parameter.
+     */
     @Override
     public String workflowStatus() {
       return "?";
     }
 
+    /**
+     * Returns SQL representing the action type parameter.
+     */
     @Override
     public String actionType() {
       return "?";
     }
 
+    /**
+     * Returns empty string as casting to text is not needed in MySQL.
+     */
     @Override
     public String castToText() {
       return "";
     }
 
+    /**
+     * Returns SQL for a query with a limit of results.
+     */
     @Override
     public String limit(String query, String limit) {
       return query + " limit " + limit;
     }
 
+    /**
+     * Returns the SQL type for long text.
+     */
     @Override
     public int longTextType() {
       return Types.VARCHAR;
     }
 
+    /**
+     * Returns true as MySQL suppports batch updates.
+     */
     @Override
     public boolean useBatchUpdate() {
       return true;

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/MysqlDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/MysqlDatabaseConfiguration.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.storage.db;
+package io.nflow.engine.config.db;
 
 import static io.nflow.engine.config.Profiles.MYSQL;
 import static java.lang.Integer.parseInt;
@@ -21,6 +21,8 @@ import org.springframework.jdbc.datasource.DataSourceUtils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.nflow.engine.config.NFlow;
+import io.nflow.engine.internal.storage.db.DatabaseInitializer;
+import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
 @Profile(MYSQL)

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/OracleDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/OracleDatabaseConfiguration.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.storage.db;
+package io.nflow.engine.config.db;
 
 import static io.nflow.engine.config.Profiles.ORACLE;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -20,6 +20,8 @@ import org.springframework.jdbc.datasource.DataSourceUtils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.nflow.engine.config.NFlow;
+import io.nflow.engine.internal.storage.db.DatabaseInitializer;
+import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
 @Profile(ORACLE)

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/OracleDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/OracleDatabaseConfiguration.java
@@ -24,6 +24,9 @@ import io.nflow.engine.internal.storage.db.DatabaseInitializer;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
+/**
+ * Configuration for Oracle database.
+ */
 @Profile(ORACLE)
 @Configuration
 public class OracleDatabaseConfiguration extends DatabaseConfiguration {
@@ -32,10 +35,19 @@ public class OracleDatabaseConfiguration extends DatabaseConfiguration {
   public static final String DB_TYPE_ORACLE = "oracle";
   private boolean useBatchUpdate;
 
+  /**
+   * Create a new instance.
+   */
   public OracleDatabaseConfiguration() {
     super(DB_TYPE_ORACLE);
   }
 
+  /**
+   * Creates the nFlow database initializer.
+   * @param dataSource The nFlow datasource.
+   * @param env The Spring environment.
+   * @return The database initializer.
+   */
   @Bean
   @Override
   @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "exception message is ok")
@@ -52,35 +64,58 @@ public class OracleDatabaseConfiguration extends DatabaseConfiguration {
     return new DatabaseInitializer(DB_TYPE_ORACLE, nflowDataSource, env);
   }
 
+  /**
+   * Creates the SQL variants for Oracle database.
+   * @return SQL variants optimized for Oracle.
+   */
   @Bean
   @DependsOn(NFLOW_DATABASE_INITIALIZER)
   public SQLVariants sqlVariants() {
     return new OracleSqlVariants(useBatchUpdate);
   }
 
+  /**
+   * SQL variants optimized for Oracle.
+   */
   public static class OracleSqlVariants implements SQLVariants {
 
     private final boolean useBatchUpdate;
 
+    /**
+     * Create a new instance.
+     * @param useBatchUpdate True for database versions 12.1 or newer.
+     */
     public OracleSqlVariants(boolean useBatchUpdate) {
       this.useBatchUpdate = useBatchUpdate;
     }
 
+    /**
+     * Returns SQL representing the current database time plus given amount of seconds.
+     */
     @Override
     public String currentTimePlusSeconds(int seconds) {
       return "current_timestamp + interval '" + seconds + "' second";
     }
 
+    /**
+     * Returns false as Oracle does not support update returning clause.
+     */
     @Override
     public boolean hasUpdateReturning() {
       return false;
     }
 
+    /**
+     * Returns false as Oracle does not support updateable CTEs.
+     */
     @Override
     public boolean hasUpdateableCTE() {
       return false;
     }
 
+    /**
+     * Returns SQL representing the next activation time of the workflow instance.
+     */
     @Override
     public String nextActivationUpdate() {
       return "(case " //
@@ -89,36 +124,57 @@ public class OracleDatabaseConfiguration extends DatabaseConfiguration {
           + "else least(?, external_next_activation) end)";
     }
 
+    /**
+     * Returns the SQL representation for given workflow instance status.
+     */
     @Override
     public String workflowStatus(WorkflowInstanceStatus status) {
       return "'" + status.name() + "'";
     }
 
+    /**
+     * Returns SQL representing the workflow instance status parameter.
+     */
     @Override
     public String workflowStatus() {
       return "?";
     }
 
+    /**
+     * Returns SQL representing the action type parameter.
+     */
     @Override
     public String actionType() {
       return "?";
     }
 
+    /**
+     * Returns empty string as casting to text is not needed in Oracle.
+     */
     @Override
     public String castToText() {
       return "";
     }
 
+    /**
+     * Returns SQL for a query with a limit of results.
+     */
     @Override
     public String limit(String query, String limit) {
       return "select * from (" + query + ") where rownum <= " + limit;
     }
 
+    /**
+     * Returns the SQL type for long text.
+     */
     @Override
     public int longTextType() {
       return Types.CLOB;
     }
 
+    /**
+     * Returns true for database versions 12.1 or newer.
+     */
     @Override
     public boolean useBatchUpdate() {
       return useBatchUpdate;

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/PgDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/PgDatabaseConfiguration.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.storage.db;
+package io.nflow.engine.config.db;
 
 import static io.nflow.engine.config.Profiles.POSTGRESQL;
 
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
 @Profile(POSTGRESQL)

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/PgDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/PgDatabaseConfiguration.java
@@ -11,35 +11,61 @@ import org.springframework.context.annotation.Profile;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
+/**
+ * Configuration for PostgreSQL database.
+ */
 @Profile(POSTGRESQL)
 @Configuration
 public class PgDatabaseConfiguration extends DatabaseConfiguration {
+
+  /**
+   * Create a new instance.
+   */
   public PgDatabaseConfiguration() {
     super("postgresql");
   }
 
-
+  /**
+   * Creates the SQL variants for PostgreSQL database.
+   * @return SQL variants optimized for PostgreSQL.
+   */
   @Bean
   public SQLVariants sqlVariants() {
     return new PostgreSQLVariants();
   }
 
+  /**
+   * SQL variants optimized for PostgreSQL.
+   */
   public static class PostgreSQLVariants implements SQLVariants {
+
+    /**
+     * Returns SQL representing the current database time plus given amount of seconds.
+     */
     @Override
     public String currentTimePlusSeconds(int seconds) {
       return "current_timestamp + interval '" + seconds + " second'";
     }
 
+    /**
+     * Returns true as PostgreSQL supports update returning clause.
+     */
     @Override
     public boolean hasUpdateReturning() {
       return true;
     }
 
+    /**
+     * Returns true as PostgreSQL supports updateable CTEs.
+     */
     @Override
     public boolean hasUpdateableCTE() {
       return true;
     }
 
+    /**
+     * Returns SQL representing the next activation time of the workflow instance.
+     */
     @Override
     public String nextActivationUpdate() {
       return "(case "
@@ -48,36 +74,57 @@ public class PgDatabaseConfiguration extends DatabaseConfiguration {
           + "else least(?::timestamptz, external_next_activation) end)";
     }
 
+    /**
+     * Returns the SQL representation for given workflow instance status.
+     */
     @Override
     public String workflowStatus(WorkflowInstanceStatus status) {
       return "'" + status.name() + "'::workflow_status";
     }
 
+    /**
+     * Returns SQL representing the workflow instance status parameter.
+     */
     @Override
     public String workflowStatus() {
       return "?::workflow_status";
     }
 
+    /**
+     * Returns SQL representing the action type parameter.
+     */
     @Override
     public String actionType() {
       return "?::action_type";
     }
 
+    /**
+     * Returns string for casting value to text.
+     */
     @Override
     public String castToText() {
       return "::text";
     }
 
+    /**
+     * Returns SQL for a query with a limit of results.
+     */
     @Override
     public String limit(String query, String limit) {
       return query + " limit " + limit;
     }
 
+    /**
+     * Returns the SQL type for long text.
+     */
     @Override
     public int longTextType() {
       return Types.VARCHAR;
     }
 
+    /**
+     * Returns true as PostgreSQL suppports batch updates.
+     */
     @Override
     public boolean useBatchUpdate() {
       return true;

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ArchiveDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ArchiveDao.java
@@ -16,7 +16,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.workflow.executor.WorkflowExecutor;
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/HealthCheckDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/HealthCheckDao.java
@@ -7,7 +7,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 
 @Named
 @SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC_ANON", justification = "common jdbctemplate practice")

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/StatisticsDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/StatisticsDao.java
@@ -19,7 +19,7 @@ import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.stereotype.Component;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.workflow.definition.WorkflowDefinitionStatistics;
 import io.nflow.engine.workflow.statistics.Statistics;
 import io.nflow.engine.workflow.statistics.Statistics.QueueStatistics;

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/TableMetadataChecker.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/TableMetadataChecker.java
@@ -18,7 +18,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.model.ModelObject;
 
 @Named

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowDefinitionDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowDefinitionDao.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.internal.workflow.StoredWorkflowDefinition;
 import io.nflow.engine.internal.workflow.StoredWorkflowDefinition.Signal;

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -64,7 +64,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.executor.InstanceInfo;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 import io.nflow.engine.internal.storage.db.SQLVariants;

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowLifecycle.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowLifecycle.java
@@ -10,7 +10,7 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 
 @Component
 public class WorkflowLifecycle implements SmartLifecycle {

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowLifecycle.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowLifecycle.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.internal.executor;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -10,7 +10,7 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
-import io.nflow.engine.internal.executor.WorkflowDispatcher;
+import io.nflow.engine.internal.config.NFlow;
 
 @Component
 public class WorkflowLifecycle implements SmartLifecycle {

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/DatabaseConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 
 public abstract class DatabaseConfiguration {
   public static final String NFLOW_DATABASE_INITIALIZER = "nflowDatabaseInitializer";

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/DatabaseInitializer.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/DatabaseInitializer.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.storage.db;
 
-import static io.nflow.engine.internal.storage.db.OracleDatabaseConfiguration.DB_TYPE_ORACLE;
+import static io.nflow.engine.config.db.OracleDatabaseConfiguration.DB_TYPE_ORACLE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.jdbc.datasource.init.DatabasePopulatorUtils.execute;

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/H2DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/H2DatabaseConfiguration.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.storage.db;
 
-import static io.nflow.engine.internal.config.Profiles.H2;
+import static io.nflow.engine.config.Profiles.H2;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.sql.SQLException;

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/MysqlDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/MysqlDatabaseConfiguration.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.storage.db;
 
-import static io.nflow.engine.internal.config.Profiles.MYSQL;
+import static io.nflow.engine.config.Profiles.MYSQL;
 import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang3.StringUtils.split;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -20,7 +20,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
 @Profile(MYSQL)

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/OracleDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/OracleDatabaseConfiguration.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.storage.db;
 
-import static io.nflow.engine.internal.config.Profiles.ORACLE;
+import static io.nflow.engine.config.Profiles.ORACLE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.sql.Connection;
@@ -19,7 +19,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 
 @Profile(ORACLE)

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/PgDatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/storage/db/PgDatabaseConfiguration.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.storage.db;
 
-import static io.nflow.engine.internal.config.Profiles.POSTGRESQL;
+import static io.nflow.engine.config.Profiles.POSTGRESQL;
 
 import java.sql.Types;
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.workflow.WorkflowStateMethod.StateParameter;
 import io.nflow.engine.workflow.definition.Mutable;
 import io.nflow.engine.workflow.definition.StateExecution;

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -20,7 +20,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.stereotype.Component;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.dao.WorkflowDefinitionDao;
 import io.nflow.engine.workflow.definition.AbstractWorkflowDefinition;
 import io.nflow.engine.workflow.definition.WorkflowDefinition;

--- a/nflow-engine/src/test/java/io/nflow/engine/config/EngineConfigurationTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/config/EngineConfigurationTest.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.config;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -21,6 +21,7 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.nflow.engine.config.EngineConfiguration;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/nflow-engine/src/test/java/io/nflow/engine/config/PropertiesConfigurationTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/config/PropertiesConfigurationTest.java
@@ -1,8 +1,10 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.config;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import io.nflow.engine.config.PropertiesConfiguration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PropertiesConfigurationTest {

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/BaseDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/BaseDaoTest.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.dao;
 
-import static io.nflow.engine.internal.config.Profiles.H2;
+import static io.nflow.engine.config.Profiles.H2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTime.now;
 import static org.springframework.jdbc.datasource.init.DatabasePopulatorUtils.execute;

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/DaoTestConfiguration.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/DaoTestConfiguration.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
-import io.nflow.engine.internal.storage.db.H2DatabaseConfiguration;
-import io.nflow.engine.internal.storage.db.H2DatabaseConfiguration.H2SQLVariants;
+import io.nflow.engine.config.db.H2DatabaseConfiguration;
+import io.nflow.engine.config.db.H2DatabaseConfiguration.H2SQLVariants;
 import io.nflow.engine.internal.workflow.ObjectStringMapper;
 import io.nflow.engine.workflow.instance.WorkflowInstanceFactory;
 

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/DaoTestConfiguration.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/DaoTestConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 import io.nflow.engine.internal.storage.db.H2DatabaseConfiguration;
 import io.nflow.engine.internal.storage.db.H2DatabaseConfiguration.H2SQLVariants;

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/TableMetadataCheckerTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/TableMetadataCheckerTest.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.dao;
 
-import static io.nflow.engine.internal.config.Profiles.H2;
+import static io.nflow.engine.config.Profiles.H2;
 
 import javax.inject.Inject;
 import javax.sql.DataSource;

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -60,7 +60,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import io.nflow.engine.internal.dao.WorkflowInstanceDao.WorkflowInstanceActionRowMapper;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
-import io.nflow.engine.internal.storage.db.PgDatabaseConfiguration.PostgreSQLVariants;
+import io.nflow.engine.config.db.PgDatabaseConfiguration.PostgreSQLVariants;
 import io.nflow.engine.service.WorkflowInstanceInclude;
 import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowLifecycleTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowLifecycleTest.java
@@ -1,4 +1,4 @@
-package io.nflow.engine.internal.config;
+package io.nflow.engine.internal.executor;
 
 import static java.lang.Boolean.TRUE;
 import static org.hamcrest.Matchers.is;
@@ -17,6 +17,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
 
 import io.nflow.engine.internal.executor.WorkflowDispatcher;
+import io.nflow.engine.internal.executor.WorkflowLifecycle;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WorkflowLifecycleTest {

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/storage/db/DatabaseInitializerTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/storage/db/DatabaseInitializerTest.java
@@ -1,6 +1,6 @@
 package io.nflow.engine.internal.storage.db;
 
-import static io.nflow.engine.internal.config.Profiles.H2;
+import static io.nflow.engine.config.Profiles.H2;
 
 import javax.inject.Inject;
 import javax.sql.DataSource;

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.dao.ArchiveDao;
 import io.nflow.engine.internal.dao.ExecutorDao;
 import io.nflow.engine.internal.dao.HealthCheckDao;

--- a/nflow-jetty/src/main/java/io/nflow/jetty/StartNflow.java
+++ b/nflow-jetty/src/main/java/io/nflow/jetty/StartNflow.java
@@ -1,6 +1,6 @@
 package io.nflow.jetty;
 
-import static io.nflow.engine.internal.config.Profiles.JMX;
+import static io.nflow.engine.config.Profiles.JMX;
 import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.list;

--- a/nflow-jetty/src/main/java/io/nflow/jetty/config/JmxConfiguration.java
+++ b/nflow-jetty/src/main/java/io/nflow/jetty/config/JmxConfiguration.java
@@ -1,6 +1,6 @@
 package io.nflow.jetty.config;
 
-import static io.nflow.engine.internal.config.Profiles.JMX;
+import static io.nflow.engine.config.Profiles.JMX;
 import static java.lang.Boolean.TRUE;
 
 import org.apache.cxf.Bus;

--- a/nflow-jetty/src/main/java/io/nflow/jetty/config/NflowJettyConfiguration.java
+++ b/nflow-jetty/src/main/java/io/nflow/jetty/config/NflowJettyConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.jetty.mapper.BadRequestExceptionMapper;
 import io.nflow.jetty.mapper.CustomValidationExceptionMapper;
 import io.nflow.jetty.mapper.NotFoundExceptionMapper;

--- a/nflow-jetty/src/main/java/io/nflow/jetty/spring/NflowStandardEnvironment.java
+++ b/nflow-jetty/src/main/java/io/nflow/jetty/spring/NflowStandardEnvironment.java
@@ -1,6 +1,6 @@
 package io.nflow.jetty.spring;
 
-import static io.nflow.engine.internal.config.Profiles.H2;
+import static io.nflow.engine.config.Profiles.H2;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
 

--- a/nflow-jetty/src/test/java/io/nflow/jetty/StartNflowTest.java
+++ b/nflow-jetty/src/test/java/io/nflow/jetty/StartNflowTest.java
@@ -1,8 +1,8 @@
 package io.nflow.jetty;
 
-import static io.nflow.engine.internal.config.Profiles.JMX;
-import static io.nflow.engine.internal.config.Profiles.MYSQL;
-import static io.nflow.engine.internal.config.Profiles.POSTGRESQL;
+import static io.nflow.engine.config.Profiles.JMX;
+import static io.nflow.engine.config.Profiles.MYSQL;
+import static io.nflow.engine.config.Profiles.POSTGRESQL;
 import static java.lang.Thread.sleep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -13,9 +13,6 @@ import static org.junit.Assert.fail;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Configurable;
-
-import io.nflow.jetty.JettyServerContainer;
-import io.nflow.jetty.StartNflow;
 
 public class StartNflowTest {
   @Test

--- a/nflow-jetty/src/test/java/io/nflow/jetty/spring/NflowStandardEnvironmentTest.java
+++ b/nflow-jetty/src/test/java/io/nflow/jetty/spring/NflowStandardEnvironmentTest.java
@@ -1,6 +1,6 @@
 package io.nflow.jetty.spring;
 
-import static io.nflow.engine.internal.config.Profiles.H2;
+import static io.nflow.engine.config.Profiles.H2;
 import static java.lang.System.clearProperty;
 import static java.lang.System.setProperty;
 import static org.hamcrest.Matchers.is;

--- a/nflow-metrics/src/main/java/io/nflow/metrics/NflowMetricsContext.java
+++ b/nflow-metrics/src/main/java/io/nflow/metrics/NflowMetricsContext.java
@@ -1,6 +1,6 @@
 package io.nflow.metrics;
 
-import static io.nflow.engine.internal.config.Profiles.JMX;
+import static io.nflow.engine.config.Profiles.JMX;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;

--- a/nflow-metrics/src/test/java/io/nflow/metrics/MetricsWorkflowExecutorListenerTest.java
+++ b/nflow-metrics/src/test/java/io/nflow/metrics/MetricsWorkflowExecutorListenerTest.java
@@ -1,8 +1,8 @@
 package io.nflow.metrics;
 
-import static io.nflow.engine.internal.config.Profiles.H2;
-import static io.nflow.engine.internal.config.Profiles.JMX;
-import static io.nflow.engine.internal.config.Profiles.METRICS;
+import static io.nflow.engine.config.Profiles.H2;
+import static io.nflow.engine.config.Profiles.JMX;
+import static io.nflow.engine.config.Profiles.METRICS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -22,7 +22,7 @@ import org.springframework.mock.env.MockEnvironment;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.dao.ExecutorDao;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.listener.WorkflowExecutorListener;

--- a/nflow-rest-api/src/main/java/io/nflow/rest/config/RestConfiguration.java
+++ b/nflow-rest-api/src/main/java/io/nflow/rest/config/RestConfiguration.java
@@ -11,8 +11,8 @@ import org.springframework.context.annotation.Import;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.nflow.engine.internal.config.EngineConfiguration;
-import io.nflow.engine.internal.config.NFlow;
+import io.nflow.engine.config.EngineConfiguration;
+import io.nflow.engine.config.NFlow;
 
 @Configuration
 @Import({ EngineConfiguration.class, NflowRestApiPropertiesConfiguration.class })

--- a/nflow-tests/src/main/java/io/nflow/tests/demo/DemoServer.java
+++ b/nflow-tests/src/main/java/io/nflow/tests/demo/DemoServer.java
@@ -1,6 +1,6 @@
 package io.nflow.tests.demo;
 
-import static io.nflow.engine.internal.config.Profiles.JMX;
+import static io.nflow.engine.config.Profiles.JMX;
 import static io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
 import static io.nflow.tests.demo.DemoWorkflow.DEMO_WORKFLOW_TYPE;
 import static io.nflow.tests.demo.SlowWorkflow.SLOW_WORKFLOW_TYPE;

--- a/nflow-tests/src/test/java/io/nflow/tests/FutureWorkflowTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/FutureWorkflowTest.java
@@ -1,6 +1,6 @@
 package io.nflow.tests;
 
-import static io.nflow.engine.internal.config.Profiles.MYSQL;
+import static io.nflow.engine.config.Profiles.MYSQL;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.cxf.jaxrs.client.WebClient.fromClient;

--- a/nflow-tests/src/test/java/io/nflow/tests/runner/NflowServerRule.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/runner/NflowServerRule.java
@@ -1,6 +1,6 @@
 package io.nflow.tests.runner;
 
-import static io.nflow.engine.internal.config.Profiles.POSTGRESQL;
+import static io.nflow.engine.config.Profiles.POSTGRESQL;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.right;
 import static org.apache.commons.lang3.StringUtils.substringAfterLast;

--- a/nflow-tests/src/test/java/io/nflow/tests/runner/SkipNotPersistedDatabaseRule.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/runner/SkipNotPersistedDatabaseRule.java
@@ -1,8 +1,8 @@
 package io.nflow.tests.runner;
 
-import static io.nflow.engine.internal.config.Profiles.MYSQL;
-import static io.nflow.engine.internal.config.Profiles.ORACLE;
-import static io.nflow.engine.internal.config.Profiles.POSTGRESQL;
+import static io.nflow.engine.config.Profiles.MYSQL;
+import static io.nflow.engine.config.Profiles.ORACLE;
+import static io.nflow.engine.config.Profiles.POSTGRESQL;
 import static java.lang.System.getenv;
 import static org.apache.commons.lang3.StringUtils.containsAny;
 import static org.junit.Assume.assumeTrue;


### PR DESCRIPTION
It is confusing that engine configuration is in internal-package, because it needs to be imported (and sometimes modified) in the applications.

1. io.nflow.engine.internal.config -> io.nflow.engine.config
2. except io.nflow.engine.internal.config.WorkflowLifecycle -> io.nflow.engine.internal.executor.WorkflowLifecycle
3. additionally configuration classes from io.nflow.engine.internal.storage.db -> io.nflow.engine.config.db