### PR TITLE
Add jackson-annotations dependency to nflow-engine

### DIFF
--- a/nflow-engine/pom.xml
+++ b/nflow-engine/pom.xml
@@ -29,6 +29,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
     </dependency>


### PR DESCRIPTION
```EngineConfiguration``` uses ```jackson-annotations```, but there was no ```pom.xml``` dependency in ```nflow-engine```. As a result ```README.md``` quickstart instructions failed, because ```nflow-jetty``` got incompatible ```jackson-annotations``` as transitive dependency through ```swagger-core```.