### PR TITLE
Actually apply the override properties first

### DIFF
--- a/nflow-server-common/src/main/java/io/nflow/server/spring/NflowStandardEnvironment.java
+++ b/nflow-server-common/src/main/java/io/nflow/server/spring/NflowStandardEnvironment.java
@@ -18,7 +18,7 @@ public class NflowStandardEnvironment extends StandardEnvironment {
   private static final Logger logger = getLogger(NflowStandardEnvironment.class);
 
   public NflowStandardEnvironment(Map<String, Object> overrideProperties) {
-    getPropertySources().addLast(new MapPropertySource("override", overrideProperties));
+    getPropertySources().addFirst(new MapPropertySource("override", overrideProperties));
     addExternalPropertyResource();
     String env = getProperty("env", "local");
     addActiveProfile(env);


### PR DESCRIPTION
This allows overriding even system environment variables. Without this the tests fail on Fedora 28 that by default has the http://modules.sourceforge.net/ installed, which happens to use an environment variable called _ENV_ that happens to match the _env_ variable used by nflow to choose the active profile name.

Long term solution would be to namespace the variable to _nflow.env_