### PR TITLE
Add nflow.swagger.packages, default: io.nflow.rest

### DIFF
--- a/nflow-jetty/src/main/java/io/nflow/jetty/config/NflowJettyConfiguration.java
+++ b/nflow-jetty/src/main/java/io/nflow/jetty/config/NflowJettyConfiguration.java
@@ -92,6 +92,7 @@ public class NflowJettyConfiguration {
     Swagger2Feature feature = new Swagger2Feature();
     feature.setBasePath("/nflow/api");
     feature.setScan(true);
+    feature.setResourcePackage(env.getProperty("nflow.swagger.packages", "io.nflow.rest"));
     feature.setContact("nFlow community (nflow-users@googlegroups.com)");
     feature.setDescription(
         "nFlow REST API provides services for managing workflow instances and querying metadata (statistics, workflow "


### PR DESCRIPTION
This field is documented as:

"a list of comma separated package names where resources must be scanned+"

at https://cwiki.apache.org/confluence/display/CXF20DOC/Swagger2Feature.