### PR TITLE
Fix (rest) apidocs redirect url for v5.0.0

### DIFF
--- a/apidocs/current/index.html
+++ b/apidocs/current/index.html
@@ -1,5 +1,5 @@
 ---
-redirect_to: /nflow/apidocs/v5.0.0/
+redirect_to: /apidocs/v5.0.0/
 ---
 <!DOCTYPE html>
 <html>

--- a/rest-apidocs/current/index.html
+++ b/rest-apidocs/current/index.html
@@ -1,5 +1,5 @@
 ---
-redirect_to: /nflow/rest-apidocs/v5.0.0/
+redirect_to: /rest-apidocs/v5.0.0/
 ---
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
nFlow (REST) API link in wiki is broken:
https://github.com/NitorCreations/nflow/wiki

Jekyll used by Github pages has probably changed the way redirect_to -directive is used. This file is generated by release.sh so another change for that.  