### PR TITLE
Allow non-final error states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Merge nFlow Explorer to nFlow repository
 
 **Details**
+- `nflow-engine`
+  - Allow non-final error states in workflow definitions
 - nFlow Explorer
   - Fix Google Chrome crash on workflow graph visualization (e.g. switching between parent and child workflow instances crashed Chrome)
   - Fix interaction between selected workflow graph node, action history row and manage state selection

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/AbstractWorkflowDefinition.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/AbstractWorkflowDefinition.java
@@ -45,7 +45,6 @@ public abstract class AbstractWorkflowDefinition<S extends WorkflowState> extend
     Assert.notNull(initialState, "initialState must not be null");
     Assert.isTrue(initialState.getType() == WorkflowStateType.start, "initialState must be a start state");
     Assert.notNull(errorState, "errorState must not be null");
-    Assert.isTrue(errorState.getType().isFinal(), "errorState must be a final state");
     this.type = type;
     this.initialState = initialState;
     this.errorState = errorState;

--- a/nflow-engine/src/test/java/io/nflow/engine/workflow/definition/WorkflowDefinitionTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/workflow/definition/WorkflowDefinitionTest.java
@@ -46,15 +46,6 @@ public class WorkflowDefinitionTest {
   }
 
   @Test
-  public void errorStateMustBeFinalState() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("errorState must be a final state");
-    new WorkflowDefinition<TestDefinition.TestState>("nonFinalErrorState", TestDefinition.TestState.start1,
-        TestDefinition.TestState.start1) {
-    };
-  }
-
-  @Test
   public void getStatesWorks() {
     TestDefinitionWithStateTypes def = new TestDefinitionWithStateTypes("x", TestDefinitionWithStateTypes.State.initial);
     assertThat(def.getStates(),


### PR DESCRIPTION
Rationale: often we want a workflow instance to halt when reaching error state. Sometimes though, there's no harm in retrying forever, but it would be useful to send alarm periodically.