### PR TITLE
Fix graph translation problem (paths sometimes out of viewbox)

### DIFF
--- a/nflow-explorer/src/app/components/index.js
+++ b/nflow-explorer/src/app/components/index.js
@@ -8,6 +8,7 @@
     'nflowExplorer.components.filters',
     'nflowExplorer.components.graph',
     'nflowExplorer.components.util',
+    'nflowExplorer.components.svgPanZoom'
   ]);
 
 })();

--- a/nflow-explorer/src/app/components/svgPanZoom.js
+++ b/nflow-explorer/src/app/components/svgPanZoom.js
@@ -1,0 +1,14 @@
+(function () {
+  'use strict';
+
+  var m = angular.module('nflowExplorer.components.svgPanZoom', []);
+
+  m.factory('svgPanZoom', function SvgPanZoomFactory($window) {
+    if (!$window.svgPanZoom) {
+      console.error('Failed to load svgPanZoom');
+      return function() {};
+    }
+    return $window.svgPanZoom;
+  });
+
+})();

--- a/nflow-explorer/src/index.html
+++ b/nflow-explorer/src/index.html
@@ -81,6 +81,7 @@
     <script src="app/components/filters.js"></script>
     <script src="app/components/graph.js"></script>
     <script src="app/components/util.js"></script>
+    <script src="app/components/svgPanZoom.js"></script>
     <script src="app/components/endpointSelection/endpointSelection.js"></script>
 
     <script src="app/executors/executors.js"></script>

--- a/nflow-explorer/src/styles/main.scss
+++ b/nflow-explorer/src/styles/main.scss
@@ -268,6 +268,8 @@ ul.listing {
 
 .svg-container {
   width: 100%;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .svg-content-responsive {


### PR DESCRIPTION
Workflow graph edges are sometimes hidden outside the viewbox after recent changes. This is fixed by ```fit: true``` for ```svgPanZoom```. The previous causes a new problem: ```fit``` does not understand stroke width leaving nodes touching the viewport edge partially drawn. This is fixed by zooming out 1% after fitting, but after this hack we do get 1) properly visible graph and 2) get rid of many magic numbers.

Includes also the following:
- increase viewport minimum height 300px -> 400px in cases we have to enable zoom
- wrap ```svgPanZoom``` into factory so that we don't get build time warnings (https://www.jvandemo.com/how-to-properly-integrate-non-angularjs-libraries-in-your-angularjs-application/)