### PR TITLE
Remove oraclejdk10 from travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk10
   - openjdk11
 env:
   global:


### PR DESCRIPTION
Oracle stopped supporting jdk10 in September 2018.