### PR TITLE
Add nflow_executor.stopped field

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
@@ -169,15 +169,18 @@ public class ExecutorDao {
         DateTime started = sqlVariants.getDateTime(rs, "started");
         DateTime active = sqlVariants.getDateTime(rs, "active");
         DateTime expires = sqlVariants.getDateTime(rs, "expires");
-        return new WorkflowExecutor(id, host, pid, executorGroup, started, active, expires);
+        DateTime stopped = sqlVariants.getDateTime(rs, "stopped");
+        return new WorkflowExecutor(id, host, pid, executorGroup, started, active, expires, stopped);
       }
     }, executorGroup);
   }
 
   public void markShutdown() {
     try {
-      jdbc.update("update nflow_executor set expires=current_timestamp where executor_group = ? and id = ?", executorGroup,
-          getExecutorId());
+      jdbc.update("update nflow_executor " +
+                      "set expires=current_timestamp, stopped=current_timestamp " +
+                      "where executor_group = ? and id = ?",
+              executorGroup, getExecutorId());
     } catch (DataAccessException e) {
       logger.warn("Failed to mark executor as expired", e);
     }

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/executor/WorkflowExecutor.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/executor/WorkflowExecutor.java
@@ -38,6 +38,10 @@ public class WorkflowExecutor extends ModelObject {
    * Time after which the executor is considered dead.
    */
   public final DateTime expires;
+  /**
+   * Time when the executor was stopped.
+   */
+  public final DateTime stopped;
 
   /**
    * Creates a new workflow executor description.
@@ -49,8 +53,10 @@ public class WorkflowExecutor extends ModelObject {
    * @param started Time when the executor was started
    * @param active Time when the executor last updated that it is active
    * @param expires Time after which the executor is considered dead
+   * @param stopped Time when the executor was stopped
    */
-  public WorkflowExecutor(int id, String host, int pid, String executorGroup, DateTime started, DateTime active, DateTime expires) {
+  public WorkflowExecutor(int id, String host, int pid, String executorGroup, DateTime started, DateTime active,
+                          DateTime expires, DateTime stopped) {
     this.id = id;
     this.host = host;
     this.pid = pid;
@@ -58,5 +64,6 @@ public class WorkflowExecutor extends ModelObject {
     this.started = started;
     this.active = active;
     this.expires = expires;
+    this.stopped = stopped;
   }
 }

--- a/nflow-engine/src/main/resources/scripts/db/h2.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/h2.create.ddl.sql
@@ -60,7 +60,8 @@ create table if not exists nflow_executor (
   executor_group varchar(64),
   started timestamp not null default current_timestamp,
   active timestamp not null,
-  expires timestamp not null
+  expires timestamp not null,
+  stopped timestamp
 );
 
 create table if not exists nflow_workflow_definition (

--- a/nflow-engine/src/main/resources/scripts/db/mysql.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/mysql.create.ddl.sql
@@ -59,7 +59,8 @@ create table if not exists nflow_executor (
   executor_group varchar(64),
   started timestamp(3) not null default current_timestamp(3),
   active timestamp(3) not null default current_timestamp(3),
-  expires timestamp(3) not null default current_timestamp(3)
+  expires timestamp(3) not null default current_timestamp(3),
+  stopped timestamp(3)
 );
 
 create table if not exists nflow_workflow_definition (

--- a/nflow-engine/src/main/resources/scripts/db/mysql.legacy.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/mysql.legacy.create.ddl.sql
@@ -64,7 +64,8 @@ create table if not exists nflow_executor (
   executor_group varchar(64),
   started timestamp not null default current_timestamp,
   active timestamp not null,
-  expires timestamp not null
+  expires timestamp not null,
+  stopped timestamp
 );
 
 create table if not exists nflow_workflow_definition (

--- a/nflow-engine/src/main/resources/scripts/db/oracle.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/oracle.create.ddl.sql
@@ -95,7 +95,8 @@ create table nflow_executor (
   executor_group varchar(64),
   started timestamp default current_timestamp not null,
   active timestamp not null,
-  expires timestamp not null
+  expires timestamp not null,
+  stopped timestamp
 )
 /
 

--- a/nflow-engine/src/main/resources/scripts/db/postgresql.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/postgresql.create.ddl.sql
@@ -75,7 +75,8 @@ create table if not exists nflow_executor (
   executor_group varchar(64),
   started timestamptz not null default current_timestamp,
   active timestamptz not null,
-  expires timestamptz not null
+  expires timestamptz not null,
+  stopped timestamp
 );
 
 create table if not exists nflow_workflow_definition (

--- a/nflow-engine/src/main/resources/scripts/db/postgresql.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/postgresql.create.ddl.sql
@@ -76,7 +76,7 @@ create table if not exists nflow_executor (
   started timestamptz not null default current_timestamp,
   active timestamptz not null,
   expires timestamptz not null,
-  stopped timestamp
+  stopped timestamptz
 );
 
 create table if not exists nflow_workflow_definition (

--- a/nflow-engine/src/main/resources/scripts/db/sqlserver.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/sqlserver.create.ddl.sql
@@ -67,7 +67,8 @@ create table nflow_executor (
   executor_group varchar(64),
   started datetimeoffset(3) not null default SYSDATETIMEOFFSET(),
   active datetimeoffset(3) not null,
-  expires datetimeoffset(3) not null
+  expires datetimeoffset(3) not null,
+  stopped datetimeoffset(3)
 );
 
 create table nflow_workflow_definition (

--- a/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/h2.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/h2.update.ddl.sql
@@ -1,0 +1,1 @@
+alter table nflow_explorer add stopped timestamp;

--- a/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/mysql.legacy.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/mysql.legacy.update.ddl.sql
@@ -1,0 +1,1 @@
+alter table nflow_explorer add stopped timestamp;

--- a/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/mysql.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/mysql.update.ddl.sql
@@ -1,0 +1,1 @@
+alter table nflow_explorer add stopped timestamp(3);

--- a/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/oracle.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/oracle.update.ddl.sql
@@ -1,0 +1,1 @@
+alter table nflow_explorer add stopped timestamp;

--- a/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/postgresql.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/postgresql.update.ddl.sql
@@ -1,0 +1,1 @@
+alter table nflow_explorer add stopped timestamp;

--- a/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/postgresql.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/postgresql.update.ddl.sql
@@ -1,1 +1,1 @@
-alter table nflow_explorer add stopped timestamp;
+alter table nflow_explorer add stopped timestamptz;

--- a/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/sqlserver.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.2.0-x/sqlserver.update.ddl.sql
@@ -1,0 +1,1 @@
+alter table nflow_explorer add stopped datetimeoffset(3);

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/ExecutorDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/ExecutorDaoTest.java
@@ -1,6 +1,8 @@
 package io.nflow.engine.internal.dao;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.joda.time.DateTime.now;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -47,6 +49,7 @@ public class ExecutorDaoTest extends BaseDaoTest {
     assertThat(executor.started, is(crashedNodeStartTime));
     assertThat(executor.active, is(crashedNodeStartTime.plusSeconds(1)));
     assertThat(executor.expires, is(crashedNodeStartTime.plusHours(1)));
+    assertThat(executor.stopped, is(nullValue()));
   }
 
   @Test
@@ -58,6 +61,9 @@ public class ExecutorDaoTest extends BaseDaoTest {
 
     dao.markShutdown();
 
-    assertThat(dao.getExecutors().get(0).expires.isAfterNow(), is(false));
+    WorkflowExecutor executor = dao.getExecutors().get(0);
+    assertThat(executor.expires.isAfterNow(), is(false));
+    assertThat(executor.stopped, is(notNullValue()));
+    assertThat(executor.stopped.isAfterNow(), is(false));
   }
 }

--- a/nflow-explorer/src/app/executors/executorTable.html
+++ b/nflow-explorer/src/app/executors/executorTable.html
@@ -8,6 +8,7 @@
       <th>Process ID</th>
       <th>Executor group</th>
       <th>Started</th>
+      <th>Stopped</th>
       <th>Activity heartbeat</th>
       <th>Heartbeat expires</th>
     </tr>
@@ -20,6 +21,7 @@
       <td>{{executor.pid}}</td>
       <td>{{executor.executorGroup}}</td>
       <td title="{{executor.started | date:'medium'}}">{{executor.started | fromNow}}</td>
+      <td title="{{executor.stopped | date:'medium'}}">{{executor.stopped | fromNow}}</td>
       <td title="{{executor.active | date:'medium'}}">{{executor.active | fromNow}}</td>
       <td title="{{executor.expires | date:'medium'}}">{{executor.expires | fromNow}}</td>
     </tr>

--- a/nflow-explorer/src/app/executors/executorTable.js
+++ b/nflow-explorer/src/app/executors/executorTable.js
@@ -39,12 +39,16 @@
 
     function executorClass(executor, now) {
       now = now || Time.currentMoment();
-      if(!executor.expires) { // has never been active
+      if (executor.stopped) {
+        return;
+      }
 
-        if(moment(executor.started).add(1, 'days').isBefore(now)) { // dead
+      if (!executor.expires) { // has never been active
+
+        if (moment(executor.started).add(1, 'days').isBefore(now)) { // dead
           return;
         }
-        if(moment(executor.started).add(1, 'hours').isBefore(now)) { // expired
+        if (moment(executor.started).add(1, 'hours').isBefore(now)) { // expired
           return 'warning';
         }
         return 'success'; // alive

--- a/nflow-explorer/test/spec/workflow-definition/statisticsTestUtil.js
+++ b/nflow-explorer/test/spec/workflow-definition/statisticsTestUtil.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function stubStatePoller(WorkflowStatsPoller, stats) {
   sinon.stub(WorkflowStatsPoller, 'getLatest').callsFake(function() {
     return {

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/converter/ListWorkflowExecutorConverter.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/converter/ListWorkflowExecutorConverter.java
@@ -17,6 +17,7 @@ public class ListWorkflowExecutorConverter {
     resp.started = executor.started;
     resp.active = executor.active;
     resp.expires = executor.expires;
+    resp.stopped = executor.stopped;
     return resp;
   }
 }

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/msg/ListWorkflowExecutorResponse.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/msg/ListWorkflowExecutorResponse.java
@@ -31,4 +31,7 @@ public class ListWorkflowExecutorResponse extends ModelObject {
 
   @ApiModelProperty(value = "Time after which the executor is considered as crashed", required=true)
   public DateTime expires;
+
+  @ApiModelProperty(value = "Time when the executor was stopped", required=true)
+  public DateTime stopped;
 }

--- a/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/ListWorkflowExecutorConverterTest.java
+++ b/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/ListWorkflowExecutorConverterTest.java
@@ -20,7 +20,7 @@ public class ListWorkflowExecutorConverterTest {
   @Test
   public void convertWorks() {
     WorkflowExecutor executor = new WorkflowExecutor(1, "host", 2, "executorGroup", now(), now().plusMinutes(1), now()
-        .plusMinutes(15));
+        .plusMinutes(15), now().plusSeconds(-7));
 
     ListWorkflowExecutorResponse resp = converter.convert(executor);
 
@@ -31,5 +31,6 @@ public class ListWorkflowExecutorConverterTest {
     assertThat(resp.started, is(executor.started));
     assertThat(resp.active, is(executor.active));
     assertThat(resp.expires, is(executor.expires));
+    assertThat(resp.stopped, is(executor.stopped));
   }
 }

--- a/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/ListWorkflowExecutorConverterTest.java
+++ b/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/ListWorkflowExecutorConverterTest.java
@@ -19,8 +19,8 @@ public class ListWorkflowExecutorConverterTest {
 
   @Test
   public void convertWorks() {
-    WorkflowExecutor executor = new WorkflowExecutor(1, "host", 2, "executorGroup", now(), now().plusMinutes(1), now()
-        .plusMinutes(15), now().plusSeconds(-7));
+    WorkflowExecutor executor = new WorkflowExecutor(1, "host", 2, "executorGroup", now(),
+            now().plusMinutes(1), now().plusMinutes(15), now().minusSeconds(7));
 
     ListWorkflowExecutorResponse resp = converter.convert(executor);
 


### PR DESCRIPTION
Add stopped field to nflow_executor table. Added corresponding field to REST API and UI.

This change requires at least a minor version number bump (-> 5.2.0).