### PR TITLE
Support returnUrl- and returnUrlLabel-parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Details**
 - Travis CI no longer runs tests with Oracle JDK 10. Only oraclejdk8 and openjdk11 are currently running Travis CI tests.
 - Upgraded Spring to version 5.1.2.RELEASE
+- Explorer displays a link in the header based on `returnUrl` and `returnUrlLabel` parameters in the Explorer opening URL
 
 ## 5.1.0 (2018-10-18)
 

--- a/nflow-explorer/src/app/layout/header.html
+++ b/nflow-explorer/src/app/layout/header.html
@@ -1,4 +1,9 @@
 <header ng-hide="ctrl.radiator">
+  <div ng-show="ctrl.returnUrl" class="container-fluid">
+    <div class="col-md-12">
+      <a class="pull-right" ng-href="{{ctrl.returnUrl}}">{{ctrl.returnUrlLabel}}</a>
+    </div>
+  </div>
   <div class="container-fluid">
     <div class="row vertical-align">
       <div class="col-md-2">

--- a/nflow-explorer/src/app/layout/layout.js
+++ b/nflow-explorer/src/app/layout/layout.js
@@ -28,7 +28,7 @@
     };
   });
 
-  m.controller('PageHeaderCtrl', function($location, $state) {
+  m.controller('PageHeaderCtrl', function($location, $state, $window) {
     var self = this;
     // nope, $stateParams.radiator wont work here
     self.radiator = !!$location.search().radiator;
@@ -36,6 +36,19 @@
     self.isExecutorsTabActive = function() { return $state.includes('executorsTab'); };
     self.isSearchTabActive = function() { return $state.includes('searchTab'); };
     self.isAboutTabActive = function() { return $state.includes('aboutTab'); };
+    self.returnUrl = getServerParamFromUrl('returnUrl', $window);
+    self.returnUrlLabel = getServerParamFromUrl('returnUrlLabel', $window) || 'Back';
+
+    function getServerParamFromUrl(paramName, $window) {
+      var searchStr = $window.location.search.substring(1);
+      var keyValues = searchStr.split('&');
+      for (var i=0; i<keyValues.length; i++) {
+        var split = keyValues[i].split('=');
+        if (split[0] === paramName) {
+          return decodeURIComponent(split[1]);
+        }
+      }
+    }
   });
 
 })();


### PR DESCRIPTION
Making it easier to link nFlow Explorer to existing browser applications. You can now give optional returnUrl- and returnUrlLabel-parameters in Explorer opening URL (in server-part = before hashbang). The parameters control "return link" shown in the upper right corner of the UI.

Examples:
- Open Explorer front page and point return link to Slashdot with custom link label: http://localhost:9000?returnUrl=https%3A%2F%2Fwww.slashdot.org&returnUrlLabel=Return%20to%20my%20favourite%20place
- Open specific workflow instance (id 2) with the same return link as in the previous item: http://localhost:9000/?returnUrl=https%3A%2F%2Fwww.slashdot.org&returnUrlLabel=Return%20to%20my%20favourite%20place#!/workflow/2