### PR TITLE
Support boxed primitives in @StateVar

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScanner.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScanner.java
@@ -2,7 +2,6 @@ package io.nflow.engine.internal.workflow;
 
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Modifier.isStatic;
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
 import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
@@ -19,7 +18,13 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScanner.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScanner.java
@@ -3,6 +3,8 @@ package io.nflow.engine.internal.workflow;
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toCollection;
 import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.util.ReflectionUtils.doWithMethods;
@@ -18,6 +20,7 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.springframework.util.ReflectionUtils.MethodFilter;
@@ -33,21 +36,15 @@ public class WorkflowDefinitionScanner {
 
   private static final Logger logger = getLogger(WorkflowDefinitionScanner.class);
 
-  private static final Set<Object> boxedPrimitiveTypes;
-  static {
-    Set<Object> set = new LinkedHashSet<>();
-    set.addAll(asList(Boolean.class, Byte.class, Integer.class, Long.class, Float.class, Double.class));
-    boxedPrimitiveTypes = Collections.unmodifiableSet(set);
-  }
+  private static final Set<Class<?>> boxedPrimitiveTypes = Stream
+          .of(Boolean.class, Byte.class, Integer.class, Long.class, Float.class, Double.class)
+          .collect(collectingAndThen(toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
 
-  private static final Set<Type> knownImmutableTypes;
-  static {
-    Set<Type> set = new LinkedHashSet<>();
-    set.addAll(asList(Boolean.TYPE, Boolean.class, Byte.TYPE, Byte.class, Character.TYPE, Character.class,
-            Short.TYPE, Short.class, Integer.TYPE, Integer.class, Long.TYPE, Long.class, Float.TYPE,
-            Float.class, Double.TYPE, Double.class, String.class, BigDecimal.class, BigInteger.class, Enum.class));
-    knownImmutableTypes = Collections.unmodifiableSet(set);
-  }
+  private static final Set<Type> knownImmutableTypes = Stream
+          .of(Boolean.TYPE, Boolean.class, Byte.TYPE, Byte.class, Character.TYPE, Character.class, Short.TYPE, Short.class,
+                  Integer.TYPE, Integer.class, Long.TYPE, Long.class, Float.TYPE, Float.class, Double.TYPE, Double.class, String.class,
+                  BigDecimal.class, BigInteger.class, Enum.class)
+          .collect(collectingAndThen(toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
 
   public Map<String, WorkflowStateMethod> getStateMethods(Class<?> definition) {
     final Map<String, WorkflowStateMethod> methods = new LinkedHashMap<>();

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScanner.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScanner.java
@@ -37,7 +37,7 @@ public class WorkflowDefinitionScanner {
   private static final Logger logger = getLogger(WorkflowDefinitionScanner.class);
 
   private static final Set<Class<?>> boxedPrimitiveTypes = Stream
-          .of(Boolean.class, Byte.class, Integer.class, Long.class, Float.class, Double.class)
+          .of(Boolean.class, Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class)
           .collect(collectingAndThen(toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
 
   private static final Set<Type> knownImmutableTypes = Stream

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScannerTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScannerTest.java
@@ -82,6 +82,90 @@ public class WorkflowDefinitionScannerTest {
   }
 
   @Test
+  public void instantiateWithBoolean() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(BooleanObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", boolean.class, true, false));
+
+    StateParameter param = methods.get("end").params[1];
+    assertThat(param, stateParam("paramBoxed", Boolean.class, true, false));
+    assertEquals(Boolean.FALSE, param.nullValue);
+  }
+
+  @Test
+  public void instantiateWithByte() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(ByteObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", byte.class, true, false));
+
+    StateParameter param = methods.get("end").params[1];
+    assertThat(param, stateParam("paramBoxed", Byte.class, true, false));
+    assertEquals((byte)0, param.nullValue);
+  }
+
+  @Test
+  public void instantiateWithCharacter() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(CharacterObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", char.class, true, false));
+
+    StateParameter param = methods.get("end").params[1];
+    assertThat(param, stateParam("paramBoxed", Character.class, true, false));
+    assertEquals((char)0, param.nullValue);
+  }
+
+  @Test
+  public void instantiateWithInteger() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(IntegerObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", int.class, true, false));
+
+    StateParameter param = methods.get("end").params[1];
+    assertThat(param, stateParam("paramBoxed", Integer.class, true, false));
+    assertEquals(Integer.valueOf(0), param.nullValue);
+  }
+
+  @Test
+  public void instantiateWithLong() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(LongObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", long.class, true, false));
+
+    StateParameter param = methods.get("end").params[1];
+    assertThat(param, stateParam("paramBoxed", Long.class, true, false));
+    assertEquals(Long.valueOf(0), param.nullValue);
+  }
+
+  @Test
+  public void instantiateWithFloat() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(FloatObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", float.class, true, false));
+
+    StateParameter param = methods.get("end").params[1];
+    assertThat(param, stateParam("paramBoxed", Float.class, true, false));
+    assertEquals(Float.valueOf(0), param.nullValue);
+  }
+
+  @Test
+  public void instantiateWithDouble() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(DoubleObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", double.class, true, false));
+
+    StateParameter longParam = methods.get("end").params[1];
+    assertThat(longParam, stateParam("paramBoxed", Double.class, true, false));
+    assertEquals(Double.valueOf(0), longParam.nullValue);
+  }
+
+  @Test
   public void onlyPublicMethodsWithCorrectSignatureAreReturned() {
     Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(NonStateMethodsWorkflow.class);
     assertThat(methods.keySet(), hasItemsOf(asList("start", "end", "doesNotReturnNextState")));
@@ -176,6 +260,76 @@ public class WorkflowDefinitionScannerTest {
     public NextAction end(StateExecution exec,
         @StateVar(value = "paramKey", instantiateIfNotExists = true) ParamObj param,
         @StateVar(value = "paramKey2", instantiateIfNotExists = true) long paramPrimitive) { return null; }
+  }
+
+  public static class BooleanObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public BooleanObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) boolean paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Boolean paramBoxed) { return null; }
+  }
+
+  public static class ByteObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public ByteObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) byte paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Byte paramBoxed) { return null; }
+  }
+
+  public static class CharacterObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public CharacterObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) char paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Character paramBoxed) { return null; }
+  }
+
+  public static class IntegerObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public IntegerObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) int paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Integer paramBoxed) { return null; }
+  }
+
+  public static class LongObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public LongObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) long paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Long paramBoxed) { return null; }
+  }
+
+  public static class FloatObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public FloatObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) float paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Float paramBoxed) { return null; }
+  }
+
+  public static class DoubleObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public DoubleObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) double paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Double paramBoxed) { return null; }
   }
 
   public static class NonStateMethodsWorkflow extends WorkflowDefinition<ScannerState> {

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScannerTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/WorkflowDefinitionScannerTest.java
@@ -118,6 +118,18 @@ public class WorkflowDefinitionScannerTest {
   }
 
   @Test
+  public void instantiateWithShort() {
+    Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(ShortObjectWorkflow.class);
+    assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
+    assertNotNull(methods.get("end").params[0].nullValue);
+    assertThat(methods.get("end").params[0], stateParam("paramPrimitive", short.class, true, false));
+
+    StateParameter param = methods.get("end").params[1];
+    assertThat(param, stateParam("paramBoxed", Short.class, true, false));
+    assertEquals(Short.valueOf((short)0), param.nullValue);
+  }
+
+  @Test
   public void instantiateWithInteger() {
     Map<String, WorkflowStateMethod> methods = scanner.getStateMethods(IntegerObjectWorkflow.class);
     assertThat(methods.keySet(), hasItemsOf(asList("start", "end")));
@@ -290,6 +302,16 @@ public class WorkflowDefinitionScannerTest {
     public NextAction end(StateExecution exec,
                           @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) char paramPrimitive,
                           @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Character paramBoxed) { return null; }
+  }
+
+  public static class ShortObjectWorkflow extends WorkflowDefinition<ScannerState> {
+    public ShortObjectWorkflow() {
+      super("instantiateNull", ScannerState.start, ScannerState.end);
+    }
+    public NextAction start(StateExecution exec) { return null; }
+    public NextAction end(StateExecution exec,
+                          @StateVar(value = "paramPrimitive", instantiateIfNotExists = true) short paramPrimitive,
+                          @StateVar(value = "paramBoxed", instantiateIfNotExists = true) Short paramBoxed) { return null; }
   }
 
   public static class IntegerObjectWorkflow extends WorkflowDefinition<ScannerState> {


### PR DESCRIPTION
Add support for boxed primitives (Integer, Float etc) to @StateVar.

Initialize static variables in static initialization block in WorkflowDefinitionScanner.