### PR TITLE
Library updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 - nFlow Explorer: Library updates to `lodash` 4.17.11 and `moment` 2.24.0
   Earlier lodash versions had this security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2018-16487
 - Use select distinct when getting preserved actions while cleaning workflow instance history
+- Dependency and plugin updates:
+    - slf4j 1.7.26
+    - spring 5.1.5.RELEASE
+    - hamcrest 2.1
+    - reactor.netty 0.8.5.RELEASE
+    - swagger 1.5.22
+    - mockito 2.24.5
+    - io.dropwizard.metrics 4.0.5
+    - mysql-connector-java 8.0.15
+    - mssql-jdbc 7.2.1.jre8
+    - hikaricp 3.3.1
+    - maven-surefire 2.22.1
 
 ## 5.3.3 (2019-02-04)
 

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <maven-source.version>3.0.1</maven-source.version>
     <maven-surefire.version>2.22.0</maven-surefire.version>
     <metrics.version>4.0.5</metrics.version>
-    <mockito.version>2.23.4</mockito.version>
+    <mockito.version>2.24.5</mockito.version>
     <mssql.version>7.2.1.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>8.0.15</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <postgresql-embedded.version>2.10</postgresql-embedded.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <reactor.netty.version>0.8.4.RELEASE</reactor.netty.version>
+    <reactor.netty.version>0.8.5.RELEASE</reactor.netty.version>
     <!-- 0.9.11 not used because https://trello.com/c/ZEcAoiSq/406-remove-05-mb-of-exceptions-farted-out-when-starting-nflow-jetty -->
     <reflections.version>0.9.11</reflections.version>
     <slf4j.version>1.7.26</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <!-- 0.9.11 not used because https://trello.com/c/ZEcAoiSq/406-remove-05-mb-of-exceptions-farted-out-when-starting-nflow-jetty -->
     <reflections.version>0.9.11</reflections.version>
     <slf4j.version>1.7.26</slf4j.version>
-    <spring.version>5.1.4.RELEASE</spring.version>
+    <spring.version>5.1.5.RELEASE</spring.version>
     <swagger.version>1.5.22</swagger.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>
     <validation.api.version>2.0.1.Final</validation.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <mockito.version>2.23.4</mockito.version>
     <mssql.version>7.2.1.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
-    <mysql.version>8.0.14</mysql.version>
+    <mysql.version>8.0.15</mysql.version>
     <nexus-staging-maven.version>1.6.8</nexus-staging-maven.version>
     <node.version>v8.11.4</node.version> <!-- https://nodejs.org/en/download/releases/ -->
     <npm.version>6.4.0</npm.version> <!-- https://github.com/npm/cli/releases -->

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <reflections.version>0.9.11</reflections.version>
     <slf4j.version>1.7.26</slf4j.version>
     <spring.version>5.1.4.RELEASE</spring.version>
-    <swagger.version>1.5.21</swagger.version>
+    <swagger.version>1.5.22</swagger.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>
     <validation.api.version>2.0.1.Final</validation.api.version>
     <versions-maven-plugin.version>2.7</versions-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <maven-shade.version>3.2.1</maven-shade.version>
     <maven-site.version>3.7.1</maven-site.version>
     <maven-source.version>3.0.1</maven-source.version>
-    <maven-surefire.version>2.22.0</maven-surefire.version>
+    <maven-surefire.version>2.22.1</maven-surefire.version>
     <metrics.version>4.0.5</metrics.version>
     <mockito.version>2.24.5</mockito.version>
     <mssql.version>7.2.1.jre8</mssql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <h2.version>1.4.197</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>
-    <hikaricp.version>3.3.0</hikaricp.version>
+    <hikaricp.version>3.3.1</hikaricp.version>
     <jackson.version>2.9.8</jackson.version>
     <jackson-databind.version>2.9.8</jackson-databind.version>
     <javassist.version>3.24.1-GA</javassist.version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <maven-site.version>3.7.1</maven-site.version>
     <maven-source.version>3.0.1</maven-source.version>
     <maven-surefire.version>2.22.0</maven-surefire.version>
-    <metrics.version>4.0.3</metrics.version>
+    <metrics.version>4.0.5</metrics.version>
     <mockito.version>2.23.4</mockito.version>
     <mssql.version>7.2.1.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <maven-surefire.version>2.22.0</maven-surefire.version>
     <metrics.version>4.0.3</metrics.version>
     <mockito.version>2.23.4</mockito.version>
-    <mssql.version>7.0.0.jre8</mssql.version>
+    <mssql.version>7.2.1.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>8.0.14</mysql.version>
     <nexus-staging-maven.version>1.6.8</nexus-staging-maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <findbugs.version>3.0.1</findbugs.version>
     <frontend-maven.version>1.6</frontend-maven.version>
     <h2.version>1.4.197</h2.version>
-    <hamcrest.version>1.3</hamcrest.version>
+    <hamcrest.version>2.1</hamcrest.version>
     <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>
     <hikaricp.version>3.3.1</hikaricp.version>
     <jackson.version>2.9.8</jackson.version>
@@ -861,6 +861,25 @@
       </dependency>
       <!-- testing -->
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>${hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>${hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- needed for junit4 -->
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>${hamcrest.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
@@ -882,12 +901,6 @@
         <groupId>org.glassfish.jersey.inject</groupId>
         <artifactId>jersey-hk2</artifactId>
         <version>${jersey.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <reactor.netty.version>0.8.4.RELEASE</reactor.netty.version>
     <!-- 0.9.11 not used because https://trello.com/c/ZEcAoiSq/406-remove-05-mb-of-exceptions-farted-out-when-starting-nflow-jetty -->
     <reflections.version>0.9.11</reflections.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.26</slf4j.version>
     <spring.version>5.1.4.RELEASE</spring.version>
     <swagger.version>1.5.21</swagger.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>


### PR DESCRIPTION
Library and maven plugin updates:
- slf4j 1.7.26
- spring 5.1.5.RELEASE
- hamcrest 2.1
- reactor.netty 0.8.5.RELEASE
- swagger 1.5.22
- mockito 2.24.5
- io.dropwizard.metrics 4.0.5
- mysql-connector-java 8.0.15
- mssql-jdbc 7.2.1.jre8
- hikaricp 3.3.1
- maven-surefire 2.22.1