### PR TITLE
nFlow explorer: Executors page tooltip time formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - h2 1.4.198
 - Fix workflow history cleanup to keep the actions that hold the latest values of state variables
 - nFlow Explorer: Custom content to workflow definition and workflow instance pages. 
+- nFlow Explorer: Executors page to use standard time formatting in tooltips 
 
 ## 5.3.3 (2019-02-04)
 

--- a/nflow-explorer/src/app/executors/executorTable.html
+++ b/nflow-explorer/src/app/executors/executorTable.html
@@ -20,10 +20,10 @@
       <td>{{executor.host}}</td>
       <td>{{executor.pid}}</td>
       <td>{{executor.executorGroup}}</td>
-      <td title="{{executor.started | date:'medium'}}">{{executor.started | fromNow}}</td>
-      <td title="{{executor.stopped | date:'medium'}}">{{executor.stopped | fromNow}}</td>
-      <td title="{{executor.active | date:'medium'}}">{{executor.active | fromNow}}</td>
-      <td title="{{executor.expires | date:'medium'}}">{{executor.expires | fromNow}}</td>
+      <td title="{{executor.started | date:'yyyy-MM-dd HH:mm:ss'}}">{{executor.started | fromNow}}</td>
+      <td title="{{executor.stopped | date:'yyyy-MM-dd HH:mm:ss'}}">{{executor.stopped | fromNow}}</td>
+      <td title="{{executor.active | date:'yyyy-MM-dd HH:mm:ss'}}">{{executor.active | fromNow}}</td>
+      <td title="{{executor.expires | date:'yyyy-MM-dd HH:mm:ss'}}">{{executor.expires | fromNow}}</td>
     </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Use standard time formatting in tooltips in Executors page.