### PR TITLE
Rollback h2 1.4.198 -> 1.4.197

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
     - mssql-jdbc 7.2.1.jre8
     - hikaricp 3.3.1
     - maven-surefire 2.22.1
-    - h2 1.4.198
 - Fix workflow history cleanup to keep the actions that hold the latest values of state variables
 - nFlow Explorer: Custom content to workflow definition and workflow instance pages. 
 - nFlow Explorer: Executors page to use standard time formatting in tooltips 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <findbugs-contrib.version>6.6.1</findbugs-contrib.version>
     <findbugs.version>3.0.1</findbugs.version>
     <frontend-maven.version>1.6</frontend-maven.version>
-    <h2.version>1.4.198</h2.version>
+    <h2.version>1.4.197</h2.version>
     <hamcrest.version>2.1</hamcrest.version>
     <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>
     <hikaricp.version>3.3.1</hikaricp.version>


### PR DESCRIPTION
1.4.198 has issues with transactions: https://github.com/h2database/h2database/issues/1795

WorkflowInstanceDaoTest.pollNextWorkflowInstancesWithPartialRaceCondition
fails randomly causing one workflow instance to
be reserved by two pollers.