### PR TITLE
Replace deprecated NCSARequestLog with CustomRequestLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - nFlow Explorer: Custom content to workflow definition and workflow instance pages. 
 - nFlow Explorer: Executors page to use standard time formatting in tooltips 
 - nFlow netty: Add support for registering Spring ApplicationListeners
-- nFLow jetty: Replace deprecated NCSARequestLog with CustomRequestLog
+- nFlow jetty: Replace deprecated NCSARequestLog with CustomRequestLog
 
 ## 5.3.3 (2019-02-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@
     - mssql-jdbc 7.2.1.jre8
     - hikaricp 3.3.1
     - maven-surefire 2.22.1
+    - jetty 9.4.15.v20190215
 - Fix workflow history cleanup to keep the actions that hold the latest values of state variables
 - nFlow Explorer: Custom content to workflow definition and workflow instance pages. 
 - nFlow Explorer: Executors page to use standard time formatting in tooltips 
 - nFlow netty: Add support for registering Spring ApplicationListeners
+- nFLow jetty: Replace deprecated NCSARequestLog with CustomRequestLog
 
 ## 5.3.3 (2019-02-04)
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <jaxws-api.version>2.3.1</jaxws-api.version>
     <jersey.version>2.28</jersey.version>
-    <jetty.version>9.4.14.v20181114</jetty.version>
+    <jetty.version>9.4.15.v20190215</jetty.version>
     <jodatime.version>2.10.1</jodatime.version>
     <junit4.version>4.12</junit4.version>
     <junit5.version>5.4.0</junit5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
       <email>timo.tiuraniemi@nitor.com</email>
       <organization>Nitor Creations</organization>
     </developer>
+    <developer>
+      <name>Ilari Kontinen</name>
+      <email>ilari.kontinen@nitor.com</email>
+      <organization>Nitor Creations</organization>
+    </developer>
   </developers>
   <modules>
     <module>nflow-engine</module>


### PR DESCRIPTION
Update Jetty to 9.4.15.v20190215 and replace deprecated NCSARequestLog in StartNflow.java. See issue: https://github.com/NitorCreations/nflow/issues/289