### PR TITLE
Log executor info on startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - `nflow-engine`
   - Retry workflow state processing until all steps in nFlow-side are executed successfully. This will prevent workflow instances from being locked in `executing` status, if e.g. database connection fails after locking the instance and before querying the full workflow instance information (`WorkflowStateProcessor`).
   - Fix #306: create empty ArrayList with default initial size
-
+  - Log more executor details on startup  
+  
 ## 5.5.0 (2019-04-04)
 
 **Highlights**

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/ExecutorDao.java
@@ -146,7 +146,10 @@ public class ExecutorDao {
         return p;
       }
     }, keyHolder);
-    return keyHolder.getKey().intValue();
+    int executorId = keyHolder.getKey().intValue();
+    logger.info("Joined executor group {} as executor {} running on host {} with process id {}.",
+            executorGroup, executorId, host, pid);
+    return executorId;
   }
 
   public void updateActiveTimestamp() {


### PR DESCRIPTION
When creating a new executor at startup, log its id, hostname and pid.

```
09.05.2019 12:47:23 INFO  [main] ngine.internal.dao.ExecutorDao - [user:] Joined executor group junit as executor 2 running on host 172.17.73.179 with process id 90761.
```