### PR TITLE
Replace references to WorkflowDefinition with AbstractWorkflowDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 5.5.1-SNAPSHOT (future release)
+## 5.6.0-SNAPSHOT (future release)
+
+**Highlights**
+- Support non-enum WorkflowStates to enable, for example, Kotlin workflow definitions by extending AbstractWorkflowDefinition.
 
 **Details**
 - Dependency and plugin updates:
@@ -8,8 +11,10 @@
 - `nflow-engine`
   - Retry workflow state processing until all steps in nFlow-side are executed successfully. This will prevent workflow instances from being locked in `executing` status, if e.g. database connection fails after locking the instance and before querying the full workflow instance information (`WorkflowStateProcessor`).
   - Fix #306: create empty ArrayList with default initial size
-  - Log more executor details on startup  
-  
+  - Log more executor details on startup
+  - Fix #311: Replace references to WorkflowDefinition with AbstractWorkflowDefinition to support non-enum WorkflowStates
+  - Use name() instead of toString() when getting workflow instance initial state name
+
 ## 5.5.0 (2019-04-04)
 
 **Highlights**

--- a/nflow-engine/pom.xml
+++ b/nflow-engine/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowInstancePreProcessor.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowInstancePreProcessor.java
@@ -33,7 +33,7 @@ public class WorkflowInstancePreProcessor {
     }
     WorkflowInstance.Builder builder = new WorkflowInstance.Builder(instance);
     if (instance.state == null) {
-      builder.setState(def.getInitialState().toString());
+      builder.setState(def.getInitialState().name());
     } else {
       if (!def.isStartState(instance.state)) {
         throw new RuntimeException("Specified state [" + instance.state + "] is not a start state.");

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.dao.WorkflowDefinitionDao;
 import io.nflow.engine.workflow.definition.AbstractWorkflowDefinition;
-import io.nflow.engine.workflow.definition.WorkflowDefinition;
 import io.nflow.engine.workflow.definition.WorkflowState;
 
 /**
@@ -35,7 +34,7 @@ public class WorkflowDefinitionService {
   private static final Logger logger = getLogger(WorkflowDefinitionService.class);
 
   private AbstractResource nonSpringWorkflowsListing;
-  private final Map<String, AbstractWorkflowDefinition<? extends WorkflowState>> workflowDefitions = new LinkedHashMap<>();
+  private final Map<String, AbstractWorkflowDefinition<? extends WorkflowState>> workflowDefinitions = new LinkedHashMap<>();
   private final WorkflowDefinitionDao workflowDefinitionDao;
   private final boolean persistWorkflowDefinitions;
 
@@ -50,7 +49,7 @@ public class WorkflowDefinitionService {
    * @param workflowDefinitions The workflow definitions to be added.
    */
   @Autowired(required = false)
-  public void setWorkflowDefinitions(Collection<WorkflowDefinition<? extends WorkflowState>> workflowDefinitions) {
+  public void setWorkflowDefinitions(Collection<AbstractWorkflowDefinition<? extends WorkflowState>> workflowDefinitions) {
     for (AbstractWorkflowDefinition<? extends WorkflowState> wd : workflowDefinitions) {
       addWorkflowDefinition(wd);
     }
@@ -67,7 +66,7 @@ public class WorkflowDefinitionService {
    * @return The workflow definition or null if not found.
    */
   public AbstractWorkflowDefinition<?> getWorkflowDefinition(String type) {
-    return workflowDefitions.get(type);
+    return workflowDefinitions.get(type);
   }
 
   /**
@@ -75,7 +74,7 @@ public class WorkflowDefinitionService {
    * @return List of workflow definitions.
    */
   public List<AbstractWorkflowDefinition<? extends WorkflowState>> getWorkflowDefinitions() {
-    return new ArrayList<>(workflowDefitions.values());
+    return new ArrayList<>(workflowDefinitions.values());
   }
 
   /**
@@ -91,7 +90,7 @@ public class WorkflowDefinitionService {
       initNonSpringWorkflowDefinitions();
     }
     if (persistWorkflowDefinitions) {
-      for (AbstractWorkflowDefinition<?> definition : workflowDefitions.values()) {
+      for (AbstractWorkflowDefinition<?> definition : workflowDefinitions.values()) {
         workflowDefinitionDao.storeWorkflowDefinition(definition);
       }
     }
@@ -103,14 +102,14 @@ public class WorkflowDefinitionService {
       while ((row = br.readLine()) != null) {
         logger.info("Preparing workflow {}", row);
         @SuppressWarnings("unchecked")
-        Class<WorkflowDefinition<? extends WorkflowState>> clazz = (Class<WorkflowDefinition<? extends WorkflowState>>) Class.forName(row);
+        Class<AbstractWorkflowDefinition<? extends WorkflowState>> clazz = (Class<AbstractWorkflowDefinition<? extends WorkflowState>>) Class.forName(row);
         addWorkflowDefinition(clazz.getDeclaredConstructor().newInstance());
       }
     }
   }
 
   public void addWorkflowDefinition(AbstractWorkflowDefinition<? extends WorkflowState> wd) {
-    AbstractWorkflowDefinition<? extends WorkflowState> conflict = workflowDefitions.put(wd.getType(), wd);
+    AbstractWorkflowDefinition<? extends WorkflowState> conflict = workflowDefinitions.put(wd.getType(), wd);
     if (conflict != null) {
       throw new IllegalStateException("Both " + wd.getClass().getName() + " and " + conflict.getClass().getName() +
           " define same workflow type: " + wd.getType());

--- a/nflow-explorer/pom.xml
+++ b/nflow-explorer/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <properties>

--- a/nflow-jetty/pom.xml
+++ b/nflow-jetty/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/nflow-metrics/pom.xml
+++ b/nflow-metrics/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.nflow</groupId>
     <artifactId>nflow-root</artifactId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/nflow-netty/pom.xml
+++ b/nflow-netty/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/nflow-perf-test/pom.xml
+++ b/nflow-perf-test/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.nflow</groupId>
     <artifactId>nflow-root</artifactId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/nflow-rest-api-common/pom.xml
+++ b/nflow-rest-api-common/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <properties>
     <EMPTY></EMPTY>

--- a/nflow-rest-api-jax-rs/pom.xml
+++ b/nflow-rest-api-jax-rs/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <properties>
     <EMPTY></EMPTY>

--- a/nflow-rest-api-spring-web/pom.xml
+++ b/nflow-rest-api-spring-web/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <properties>
     <EMPTY></EMPTY>

--- a/nflow-server-common/pom.xml
+++ b/nflow-server-common/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <artifactId>nflow-root</artifactId>
     <groupId>io.nflow</groupId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/nflow-tests/pom.xml
+++ b/nflow-tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.nflow</groupId>
     <artifactId>nflow-root</artifactId>
-    <version>5.5.1-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>nflow-root</artifactId>
   <packaging>pom</packaging>
   <description>nFlow Root</description>
-  <version>5.5.1-SNAPSHOT</version>
+  <version>5.6.0-SNAPSHOT</version>
   <url>http://nflow.io</url>
   <licenses>
     <license>


### PR DESCRIPTION
This will fix issue #311 by replacing references to WorkflowDefinition (which requires use of enum) with AbstractWorkflowDefinition (which works with any WorkflowState type classes).