### PR TITLE
Dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@
   - Add started timestamp to workflow instance table. This makes the instance queries much faster when instances have lots of actions, as there is no need to join the nflow_workflow_action table to the query anymore.
   - Deprecated WorkflowInstanceInclude.STARTED enum value. This is not needed anymore, since the started timestamp is always read from the database when the instance is loaded.
   - Moved default implementations for `WorkflowExecutorListener` interface methods from the abstract class to the interface.
+- Dependency updates:
+    - reactor.netty 0.8.8.RELEASE
+    - jetty 9.4.18.v20190429
+    - javassist 3.25.0-GA
+    - mysql-connector-java 8.0.16
+    - mssql-jdbc 7.2.2.jre8
+    - metrics 4.1.0
+    - spring 5.1.7.RELEASE
+    - hibernate.validator 6.0.15.Final
+    - cxf 3.3.2
+    - joda-time 2.10.2
+    - commons-lang3 3.9
+    - jackson 2.9.9
+    - junit 5.4.1
+    - mockito 2.27.0
 
 ## 5.6.0 (2019-05-21)
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <jaxws-api.version>2.3.1</jaxws-api.version>
     <jersey.version>2.28</jersey.version>
     <jetty.version>9.4.17.v20190418</jetty.version>
-    <jodatime.version>2.10.1</jodatime.version>
+    <jodatime.version>2.10.2</jodatime.version>
     <junit4.version>4.12</junit4.version>
     <junit5.version>5.4.1</junit5.version>
     <mockito-junit-jupiter.version>2.27.0</mockito-junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <maven-site.version>3.7.1</maven-site.version>
     <maven-source.version>3.0.1</maven-source.version>
     <maven-surefire.version>2.22.1</maven-surefire.version>
-    <metrics.version>4.0.5</metrics.version>
+    <metrics.version>4.1.0</metrics.version>
     <mockito.version>2.27.0</mockito.version>
     <mssql.version>7.2.1.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <jaxws-api.version>2.3.1</jaxws-api.version>
     <jersey.version>2.28</jersey.version>
-    <jetty.version>9.4.17.v20190418</jetty.version>
+    <jetty.version>9.4.18.v20190429</jetty.version>
     <jodatime.version>2.10.2</jodatime.version>
     <junit4.version>4.12</junit4.version>
     <junit5.version>5.4.1</junit5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <jetty.version>9.4.17.v20190418</jetty.version>
     <jodatime.version>2.10.1</jodatime.version>
     <junit4.version>4.12</junit4.version>
-    <junit5.version>5.4.0</junit5.version>
+    <junit5.version>5.4.1</junit5.version>
     <mockito-junit-jupiter.version>2.27.0</mockito-junit-jupiter.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <logback-classic.version>1.2.3</logback-classic.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <hikaricp.version>3.3.1</hikaricp.version>
     <jackson.version>2.9.9</jackson.version>
     <jackson-databind.version>2.9.9</jackson-databind.version>
-    <javassist.version>3.24.1-GA</javassist.version>
+    <javassist.version>3.25.0-GA</javassist.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <javax.ws.rs.version>2.1.1</javax.ws.rs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
     <hamcrest.version>2.1</hamcrest.version>
     <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>
     <hikaricp.version>3.3.1</hikaricp.version>
-    <jackson.version>2.9.8</jackson.version>
-    <jackson-databind.version>2.9.8</jackson-databind.version>
+    <jackson.version>2.9.9</jackson.version>
+    <jackson-databind.version>2.9.9</jackson-databind.version>
     <javassist.version>3.24.1-GA</javassist.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <mockito.version>2.27.0</mockito.version>
     <mssql.version>7.2.2.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
-    <mysql.version>8.0.15</mysql.version>
+    <mysql.version>8.0.16</mysql.version>
     <nexus-staging-maven.version>1.6.8</nexus-staging-maven.version>
     <node.version>v8.11.4</node.version> <!-- https://nodejs.org/en/download/releases/ -->
     <npm.version>6.4.0</npm.version> <!-- https://github.com/npm/cli/releases -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <jodatime.version>2.10.1</jodatime.version>
     <junit4.version>4.12</junit4.version>
     <junit5.version>5.4.0</junit5.version>
-    <mockito-junit-jupiter.version>2.25.0</mockito-junit-jupiter.version>
+    <mockito-junit-jupiter.version>2.27.0</mockito-junit-jupiter.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <logback-classic.version>1.2.3</logback-classic.version>
     <maven-assembly.version>3.1.1</maven-assembly.version>
@@ -155,7 +155,7 @@
     <maven-source.version>3.0.1</maven-source.version>
     <maven-surefire.version>2.22.1</maven-surefire.version>
     <metrics.version>4.0.5</metrics.version>
-    <mockito.version>2.24.5</mockito.version>
+    <mockito.version>2.27.0</mockito.version>
     <mssql.version>7.2.1.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>8.0.15</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
   </modules>
   <properties>
     <jdk.version>1.8</jdk.version>
-    <apache.cxf.version>3.3.0</apache.cxf.version>
+    <apache.cxf.version>3.3.2</apache.cxf.version>
     <commons.lang.version>2.6</commons.lang.version>
     <commons.lang3.version>3.9</commons.lang3.version>
     <core-utils.version>1.4</core-utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <!-- 0.9.11 not used because https://trello.com/c/ZEcAoiSq/406-remove-05-mb-of-exceptions-farted-out-when-starting-nflow-jetty -->
     <reflections.version>0.9.11</reflections.version>
     <slf4j.version>1.7.26</slf4j.version>
-    <spring.version>5.1.6.RELEASE</spring.version>
+    <spring.version>5.1.7.RELEASE</spring.version>
     <swagger.version>1.5.22</swagger.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>
     <validation.api.version>2.0.1.Final</validation.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <maven-surefire.version>2.22.1</maven-surefire.version>
     <metrics.version>4.1.0</metrics.version>
     <mockito.version>2.27.0</mockito.version>
-    <mssql.version>7.2.1.jre8</mssql.version>
+    <mssql.version>7.2.2.jre8</mssql.version>
     <multithreadedtc.version>1.01</multithreadedtc.version>
     <mysql.version>8.0.15</mysql.version>
     <nexus-staging-maven.version>1.6.8</nexus-staging-maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
     <postgresql-embedded.version>2.10</postgresql-embedded.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <reactor.netty.version>0.8.6.RELEASE</reactor.netty.version>
+    <reactor.netty.version>0.8.8.RELEASE</reactor.netty.version>
     <!-- 0.9.11 not used because https://trello.com/c/ZEcAoiSq/406-remove-05-mb-of-exceptions-farted-out-when-starting-nflow-jetty -->
     <reflections.version>0.9.11</reflections.version>
     <slf4j.version>1.7.26</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <jdk.version>1.8</jdk.version>
     <apache.cxf.version>3.3.0</apache.cxf.version>
     <commons.lang.version>2.6</commons.lang.version>
-    <commons.lang3.version>3.8.1</commons.lang3.version>
+    <commons.lang3.version>3.9</commons.lang3.version>
     <core-utils.version>1.4</core-utils.version>
     <coveralls.version>4.3.0</coveralls.version>
     <el.version>3.0.0</el.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <frontend-maven.version>1.6</frontend-maven.version>
     <h2.version>1.4.199</h2.version>
     <hamcrest.version>2.1</hamcrest.version>
-    <hibernate.validator.version>6.0.13.Final</hibernate.validator.version>
+    <hibernate.validator.version>6.0.15.Final</hibernate.validator.version>
     <hikaricp.version>3.3.1</hikaricp.version>
     <jackson.version>2.9.9</jackson.version>
     <jackson-databind.version>2.9.9</jackson-databind.version>


### PR DESCRIPTION
- reactor.netty 0.8.8.RELEASE
- jetty 9.4.18.v20190429
- javassist 3.25.0-GA
- mysql-connector-java 8.0.16
- mssql-jdbc 7.2.2.jre8
- metrics 4.1.0
- spring 5.1.7.RELEASE
- hibernate.validator 6.0.15.Final
- cxf 3.3.2
- joda-time 2.10.2
- commons-lang3 3.9
- jackson 2.9.9
- junit 5.4.1
- mockito 2.27.0