### PR TITLE
Add NflowEngine class for starting nflow-engine easily.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `started` timestamp to workflow instance table (requires database update)
 - Deprecated WorkflowInstanceInclude.STARTED enum value
 - Deprecated `AbstractWorkflowExecutorListener`, use `WorkflowExecutorListener` instead
+- Allow easily starting nflow-engine for embedding via `NflowEngine` class. 
 
 **Details**
 - `nflow-engine`

--- a/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
@@ -39,7 +39,8 @@ public class NflowEngine implements Runnable {
                        SQLVariants sqlVariants,
                        Collection<AbstractWorkflowDefinition<? extends WorkflowState>> workflowDefinitions) {
         AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
-        ctx.registerBean(DataSource.class, () -> dataSource);
+
+        ctx.registerBean("nflowDatasource", DataSource.class, () -> dataSource);
         ctx.registerBean(SQLVariants.class, () -> sqlVariants);
         ctx.register(EngineConfiguration.class, NflowEngineSpringConfig.class);
         ctx.refresh();

--- a/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
@@ -24,7 +24,7 @@ import java.util.Collection;
  *
  * Use this if you want to start just the nflow-engine.
  */
-public class NflowEngine implements Runnable {
+public class NflowEngine implements Runnable, AutoCloseable {
 
     private final WorkflowDispatcher workflowDispatcher;
 
@@ -79,6 +79,11 @@ public class NflowEngine implements Runnable {
 
     public boolean isRunning() {
         return workflowDispatcher.isRunning();
+    }
+
+    @Override
+    public void close() {
+        this.shutdown();
     }
 
     @EnableTransactionManagement

--- a/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
@@ -82,7 +82,7 @@ public class NflowEngine implements AutoCloseable {
     }
 
     /**
-     * Resumes paused the nFlow engine.
+     * Resumes a paused nFlow engine.
      */
     public void resume() {
         workflowLifecycle.resume();

--- a/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
@@ -1,0 +1,108 @@
+package io.nflow.engine;
+
+import io.nflow.engine.config.EngineConfiguration;
+import io.nflow.engine.config.NFlow;
+import io.nflow.engine.internal.executor.WorkflowDispatcher;
+import io.nflow.engine.internal.storage.db.SQLVariants;
+import io.nflow.engine.service.*;
+import io.nflow.engine.workflow.definition.AbstractWorkflowDefinition;
+import io.nflow.engine.workflow.definition.WorkflowState;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+
+/**
+ * NflowEngine starts up nflow-engine with given database and workflow definitions.
+ *
+ * Use this if you want to start just the nflow-engine.
+ */
+public class NflowEngine implements Runnable {
+
+    private final WorkflowDispatcher workflowDispatcher;
+
+    public final ArchiveService archiveService;
+    public final HealthCheckService healthCheckService;
+    public final StatisticsService statisticsService;
+    public final WorkflowDefinitionService workflowDefinitionService;
+    public final WorkflowInstanceService workflowInstanceService;
+    public final WorkflowExecutorService workflowExecutorService;
+
+    public NflowEngine(DataSource dataSource,
+                       SQLVariants sqlVariants,
+                       Collection<AbstractWorkflowDefinition<? extends WorkflowState>> workflowDefinitions) {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+        ctx.registerBean(DataSource.class, () -> dataSource);
+        ctx.registerBean(SQLVariants.class, () -> sqlVariants);
+        ctx.register(EngineConfiguration.class, NflowEngineSpringConfig.class);
+        ctx.refresh();
+
+        workflowDispatcher = ctx.getBean(WorkflowDispatcher.class);
+
+        workflowDefinitionService = ctx.getBean(WorkflowDefinitionService.class);
+        workflowDefinitionService.setWorkflowDefinitions(workflowDefinitions);
+
+        archiveService = ctx.getBean(ArchiveService.class);
+        healthCheckService = ctx.getBean(HealthCheckService.class);
+        statisticsService = ctx.getBean(StatisticsService.class);
+        workflowInstanceService = ctx.getBean(WorkflowInstanceService.class);
+        workflowExecutorService = ctx.getBean(WorkflowExecutorService.class);
+    }
+
+    public void run() {
+        workflowDispatcher.run();
+    }
+
+    public void shutdown() {
+        workflowDispatcher.shutdown();
+    }
+
+    public void pause() {
+        workflowDispatcher.pause();
+    }
+
+    public void resume() {
+        workflowDispatcher.resume();
+    }
+
+    public boolean isPaused() {
+        return workflowDispatcher.isPaused();
+    }
+
+    public boolean isRunning() {
+        return workflowDispatcher.isRunning();
+    }
+
+    @EnableTransactionManagement
+    protected static class NflowEngineSpringConfig {
+        @Bean
+        @NFlow
+        public JdbcTemplate jdbcTemplate(DataSource dataSource) {
+            return new JdbcTemplate(dataSource);
+        }
+
+        @Bean
+        @NFlow
+        public NamedParameterJdbcTemplate namedParameterJdbcTemplate(DataSource dataSource) {
+            return new NamedParameterJdbcTemplate(dataSource);
+        }
+
+        @Bean
+        @NFlow
+        public TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+            return new TransactionTemplate(transactionManager);
+        }
+
+        @Bean
+        public PlatformTransactionManager transactionManager(DataSource ds) {
+            return new DataSourceTransactionManager(ds);
+        }
+    }
+}

--- a/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
@@ -103,7 +103,8 @@ public class NflowEngine implements AutoCloseable {
     }
 
     /**
-     * Shuts down the nFlow engine.
+     * Shuts down the nFlow engine gracefully and returns when the shutdown is complete.
+     * This NflowEngine instance may not be restarted after close().
      */
     @Override
     public void close() {

--- a/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/NflowEngine.java
@@ -2,7 +2,6 @@ package io.nflow.engine;
 
 import io.nflow.engine.config.EngineConfiguration;
 import io.nflow.engine.config.NFlow;
-import io.nflow.engine.internal.executor.WorkflowDispatcher;
 import io.nflow.engine.internal.executor.WorkflowLifecycle;
 import io.nflow.engine.internal.storage.db.SQLVariants;
 import io.nflow.engine.service.*;
@@ -75,47 +74,80 @@ public class NflowEngine implements AutoCloseable {
         workflowLifecycle.start();
     }
 
+    /**
+     * Pauses a running nFlow engine.
+     */
     public void pause() {
         workflowLifecycle.pause();
     }
 
+    /**
+     * Resumes paused the nFlow engine.
+     */
     public void resume() {
         workflowLifecycle.resume();
     }
 
+    /**
+     * Returns true if the nFlow engine is currently paused.
+     */
     public boolean isPaused() {
         return workflowLifecycle.isPaused();
     }
 
+    /**
+     * Returns true if the nFlow engine is currently running.
+     */
     public boolean isRunning() {
         return workflowLifecycle.isRunning();
     }
 
+    /**
+     * Shuts down the nFlow engine.
+     */
     @Override
     public void close() {
         ctx.close();
     }
 
+    /**
+     * @return ArchiveService for nFlow engine.
+     */
     public ArchiveService getArchiveService() {
         return archiveService;
     }
 
+    /**
+     * @return HealthCheckService for nFlow engine.
+     */
     public HealthCheckService getHealthCheckService() {
         return healthCheckService;
     }
 
+    /**
+     * @return StatisticsService for nFlow engine.
+     */
     public StatisticsService getStatisticsService() {
         return statisticsService;
     }
 
+    /**
+     * @return WorkflowDefinitionService for nFlow engine.
+     */
     public WorkflowDefinitionService getWorkflowDefinitionService() {
         return workflowDefinitionService;
     }
 
+    /**
+     * @return WorkflowInstanceService for nFlow engine.
+     */
     public WorkflowInstanceService getWorkflowInstanceService() {
         return workflowInstanceService;
     }
 
+    /**
+     * @return WorkflowExecutorService for nFlow engine.
+     */
     public WorkflowExecutorService getWorkflowExecutorService() {
         return workflowExecutorService;
     }

--- a/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
@@ -57,9 +57,9 @@ public class NflowEngineTest {
                     .setNextActivation(DateTime.now())
                     .build();
 
-            List<WorkflowExecutor> executors = nflowEngine.workflowExecutorService.getWorkflowExecutors();
+            List<WorkflowExecutor> executors = nflowEngine.getWorkflowExecutorService().getWorkflowExecutors();
             assertEquals(1, executors.size());
-            nflowEngine.workflowInstanceService.insertWorkflowInstance(newInstance);
+            nflowEngine.getWorkflowInstanceService().insertWorkflowInstance(newInstance);
 
             WorkflowInstance instance1 = getInstance(nflowEngine, 1);
             assertNotNull(instance1);
@@ -81,14 +81,8 @@ public class NflowEngineTest {
     }
 
     private WorkflowInstance getInstance(NflowEngine nflowEngine, int id) {
-        QueryWorkflowInstances query = new QueryWorkflowInstances.Builder()
-                .addTypes("dummy")
-                .build();
-        Collection<WorkflowInstance> results = nflowEngine.workflowInstanceService.listWorkflowInstances(query);
-        logger.info("Results {}", results);
-        assertEquals(1, results.size());
         Set<WorkflowInstanceInclude> includes = new LinkedHashSet<>(asList(WorkflowInstanceInclude.values()));
-        return nflowEngine.workflowInstanceService.getWorkflowInstance(id, includes, 100l);
+        return nflowEngine.getWorkflowInstanceService().getWorkflowInstance(id, includes, 100l);
     }
 
     public static DataSource dataSource() {

--- a/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
@@ -51,10 +51,7 @@ public class NflowEngineTest {
     @Test
     public void test() throws InterruptedException {
         Collection<AbstractWorkflowDefinition<? extends WorkflowState>> workflowDefinitions = asList(new DummyTestWorkflow());
-        NflowEngine nflowEngine = null;
-        try {
-            nflowEngine = new NflowEngine(dataSource(), new H2DatabaseConfiguration.H2SQLVariants(), workflowDefinitions);
-
+        try (NflowEngine nflowEngine = new NflowEngine(dataSource(), new H2DatabaseConfiguration.H2SQLVariants(), workflowDefinitions)){
             WorkflowInstance newInstance = new WorkflowInstance.Builder()
                     .setType("dummy")
                     .setNextActivation(DateTime.now())
@@ -83,10 +80,6 @@ public class NflowEngineTest {
             // instance is processed because nextActivation is set to null
             WorkflowInstance instance2 = getInstance(nflowEngine, 1);
             assertNull(instance2.nextActivation);
-        } finally {
-            if (nflowEngine != null) {
-                nflowEngine.shutdown();
-            }
         }
     }
 

--- a/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
@@ -1,0 +1,89 @@
+package io.nflow.engine;
+
+import io.nflow.engine.config.db.H2DatabaseConfiguration;
+import io.nflow.engine.service.DummyTestWorkflow;
+import io.nflow.engine.service.WorkflowInstanceInclude;
+import io.nflow.engine.workflow.definition.AbstractWorkflowDefinition;
+import io.nflow.engine.workflow.definition.WorkflowState;
+import io.nflow.engine.workflow.executor.WorkflowExecutor;
+import io.nflow.engine.workflow.instance.WorkflowInstance;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.jdbc.datasource.init.DatabasePopulatorUtils.execute;
+
+public class NflowEngineTest {
+
+    @Test
+    public void test() throws InterruptedException {
+        Collection<AbstractWorkflowDefinition<? extends WorkflowState>> workflowDefinitions = asList(new DummyTestWorkflow());
+        NflowEngine nflowEngine = null;
+        try {
+            nflowEngine = new NflowEngine(dataSource(), new H2DatabaseConfiguration.H2SQLVariants(), workflowDefinitions);
+
+            WorkflowInstance newInstance = new WorkflowInstance.Builder()
+                    .setType("dummy")
+                    .setNextActivation(DateTime.now())
+                    .build();
+
+            List<WorkflowExecutor> executors = nflowEngine.workflowExecutorService.getWorkflowExecutors();
+            assertEquals(1, executors.size());
+            nflowEngine.workflowInstanceService.insertWorkflowInstance(newInstance);
+
+            WorkflowInstance instance1 = nflowEngine.workflowInstanceService.getWorkflowInstance(1, Set.of(WorkflowInstanceInclude.values()), 100l);
+            assertNotNull(instance1);
+            assertEquals("dummy", instance1.type);
+            assertNotNull(instance1.nextActivation);
+
+            Thread thread = new Thread(nflowEngine);
+            thread.start();
+
+            while (!nflowEngine.isRunning()) {
+                Thread.sleep(100);
+            }
+
+            while (getInstance(nflowEngine, 1).nextActivation != null) {
+                Thread.sleep(100);
+            }
+
+            // instance is processed because nextActivation is set to null
+            WorkflowInstance instance2 = getInstance(nflowEngine, 1);
+            assertNull(instance2.nextActivation);
+        } finally {
+            nflowEngine.shutdown();
+        }
+    }
+
+    private WorkflowInstance getInstance(NflowEngine nflowEngine, int id) {
+        return nflowEngine.workflowInstanceService.getWorkflowInstance(1, Set.of(WorkflowInstanceInclude.values()), 100l);
+    }
+
+    public static DataSource dataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:enginetest;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("sa");
+        createTables(dataSource);
+        return dataSource;
+    }
+
+    public static void createTables(DataSource dataSource) {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.setIgnoreFailedDrops(true);
+        populator.setSqlScriptEncoding(UTF_8.name());
+        populator.addScript(new ClassPathResource("scripts/db/h2.create.ddl.sql"));
+        execute(populator, dataSource);
+    }
+}

--- a/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
@@ -66,9 +66,6 @@ public class NflowEngineTest {
             assertEquals("dummy", instance1.type);
             assertNotNull(instance1.nextActivation);
 
-            Thread thread = new Thread(nflowEngine);
-            thread.start();
-
             while (!nflowEngine.isRunning()) {
                 Thread.sleep(100);
             }

--- a/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/NflowEngineTest.java
@@ -6,15 +6,19 @@ import io.nflow.engine.service.WorkflowInstanceInclude;
 import io.nflow.engine.workflow.definition.AbstractWorkflowDefinition;
 import io.nflow.engine.workflow.definition.WorkflowState;
 import io.nflow.engine.workflow.executor.WorkflowExecutor;
+import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 
 import javax.sql.DataSource;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -24,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.jdbc.datasource.init.DatabasePopulatorUtils.execute;
 
 public class NflowEngineTest {
+    private static final Logger logger = LoggerFactory.getLogger(NflowEngineTest.class);
 
     @Test
     public void test() throws InterruptedException {
@@ -41,7 +46,7 @@ public class NflowEngineTest {
             assertEquals(1, executors.size());
             nflowEngine.workflowInstanceService.insertWorkflowInstance(newInstance);
 
-            WorkflowInstance instance1 = nflowEngine.workflowInstanceService.getWorkflowInstance(1, Set.of(WorkflowInstanceInclude.values()), 100l);
+            WorkflowInstance instance1 = getInstance(nflowEngine, 1);
             assertNotNull(instance1);
             assertEquals("dummy", instance1.type);
             assertNotNull(instance1.nextActivation);
@@ -66,7 +71,11 @@ public class NflowEngineTest {
     }
 
     private WorkflowInstance getInstance(NflowEngine nflowEngine, int id) {
-        return nflowEngine.workflowInstanceService.getWorkflowInstance(1, Set.of(WorkflowInstanceInclude.values()), 100l);
+        QueryWorkflowInstances query = new QueryWorkflowInstances.Builder()
+                .addTypes("dummy")
+                .build();
+        Set<WorkflowInstanceInclude> includes = new LinkedHashSet<>(asList(WorkflowInstanceInclude.values()));
+        return nflowEngine.workflowInstanceService.getWorkflowInstance(id, includes, 100l);
     }
 
     public static DataSource dataSource() {


### PR DESCRIPTION
NflowEngine starts the nflow-engine and the caller doesn't need to use or worry about Spring setup.