### PR TITLE
No mariadb for mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Details**
 - `nflow-engine`
   - Separate workflow definition scanning from `WorkflowDefinitionService` by introducing `WorkflowDefinitionSpringBeanScanner` and `WorkflowDefinitionClassNameScanner`. This allows breaking the circular dependency when a workflow definition uses `WorkflowInstanceService` (which depends on `WorkflowDefinitionService`, which depended on all workflow definitions). This enabled using constructor injection in all nFlow classes. 
+  - add `disableMariaDbDriver` to default mysql jdbc url so that in case there are both mysql and mariadb jbc drivers in classpath the mariadb will not steal the mysql url
 
 ## 5.7.0 (2019-06-06)
 

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -30,7 +30,7 @@ nflow.db.h2.tcp.port=8043
 nflow.db.h2.console.port=8044
 
 nflow.db.mysql.driver=com.mysql.cj.jdbc.Driver
-nflow.db.mysql.url=jdbc:mysql://localhost/nflow
+nflow.db.mysql.url=jdbc:mysql://localhost/nflow?disableMariaDbDriver
 nflow.db.mysql.user=nflow
 nflow.db.mysql.password=nflow
 

--- a/nflow-tests/src/main/resources/local.properties
+++ b/nflow-tests/src/main/resources/local.properties
@@ -4,17 +4,3 @@ terminate.timeout=30
 extra.resource.directories=
 
 nflow.non_spring_workflows_filename=nflow-workflows.txt
-
-## Example configuration for postgresql.
-## To enable postgres you also need set VM parameter -Dspring.profiles.active=nflow.db.postgresql
-nflow.db.postgresql.driver=org.postgresql.Driver
-nflow.db.postgresql.url=jdbc:postgresql://localhost/nflow
-nflow.db.postgresql.user=nflow
-nflow.db.postgresql.password=nflow
-
-## Example configuration for MySQL / MariaDB.
-## To enable postgres you also need set VM parameter -Dspring.profiles.active=nflow.db.mysql
-nflow.db.mysql.driver=com.mysql.cj.jdbc.Driver
-nflow.db.mysql.url=jdbc:mysql://localhost/nflow
-nflow.db.mysql.user=nflow
-nflow.db.mysql.password=nflow


### PR DESCRIPTION
This is the only way to have both maridb and mysql jdbc drivers in the classpath at the same time