### PR TITLE
Improvements and fixes for h2 and mssql ddl scripts

### DIFF
--- a/nflow-engine/src/main/resources/scripts/db/h2.create.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/h2.create.ddl.sql
@@ -41,10 +41,10 @@ create table if not exists nflow_workflow_action (
   foreign key (workflow_id) references nflow_workflow(id) on delete cascade
 );
 
-alter table nflow_workflow add constraint fk_workflow_parent
+alter table nflow_workflow add constraint if not exists fk_workflow_parent
   foreign key (parent_workflow_id, parent_action_id) references nflow_workflow_action (workflow_id, id) on delete cascade;
 
-alter table nflow_workflow add constraint fk_workflow_root
+alter table nflow_workflow add constraint if not exists fk_workflow_root
   foreign key (root_workflow_id) references nflow_workflow (id) on delete cascade;
 
 create table if not exists nflow_workflow_state (

--- a/nflow-engine/src/main/resources/scripts/db/update-5.6.0-x/h2.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.6.0-x/h2.update.ddl.sql
@@ -1,7 +1,10 @@
 alter table nflow_workflow add started timestamp;
 alter table nflow_archive_workflow add started timestamp;
 
-update nflow_workflow w, (select workflow_id, min(execution_start) as started from nflow_workflow_action group by workflow_id) a
-  set w.started = a.started, w.modified = w.modified where w.id = a.workflow_id;
-update nflow_archive_workflow w, (select workflow_id, min(execution_start) as started from nflow_archive_workflow_action group by workflow_id) a
-  set w.started = a.started, w.modified = w.modified where w.id = a.workflow_id;
+update nflow_workflow w set
+  started=(select min(execution_start) from nflow_workflow_action a where a.workflow_id = w.id group by a.workflow_id),
+  modified=w.modified;
+
+update nflow_archive_workflow w set
+  started=(select min(execution_start) from nflow_archive_workflow_action a where a.workflow_id = w.id group by a.workflow_id),
+  modified=w.modified;

--- a/nflow-engine/src/main/resources/scripts/db/update-5.6.0-x/sqlserver.update.ddl.sql
+++ b/nflow-engine/src/main/resources/scripts/db/update-5.6.0-x/sqlserver.update.ddl.sql
@@ -1,7 +1,20 @@
 alter table nflow_workflow add started datetimeoffset(3);
 alter table nflow_archive_workflow add started datetimeoffset(3);
 
-update nflow_workflow w, (select workflow_id, min(execution_start) as started from nflow_workflow_action group by workflow_id) a
-  set w.started = a.started, w.modified = w.modified where w.id = a.workflow_id;
-update nflow_archive_workflow w, (select workflow_id, min(execution_start) as started from nflow_archive_workflow_action group by workflow_id) a
-  set w.started = a.started, w.modified = w.modified where w.id = a.workflow_id;
+go
+
+update w set
+  w.started = a.started,
+  w.modified = w.modified
+from
+  nflow_workflow w,
+  (select workflow_id, min(execution_start) as started from nflow_workflow_action group by workflow_id) a
+where w.id = a.workflow_id;
+
+update w set
+  w.started = a.started,
+  w.modified = w.modified
+from
+  nflow_archive_workflow w,
+  (select workflow_id, min(execution_start) as started from nflow_archive_workflow_action group by workflow_id) a
+where w.id = a.workflow_id;


### PR DESCRIPTION
Improvements for h2 create ddl, added trigger "if not exists" clause.
Improvements for mssql create ddl, added mssql style "if not exists" clauses.
Fix h2 and mssql latest update ddl (update-5.6.0-X) column `started` populating.

MSSQL scripts verified with MSSQL 2017-CU14-ubuntu and AzureSQL.