### PR TITLE
Add nflow.db.disable_batch_updates, default to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add Kotlin example using nFlow with Spring Boot, and integrated nFlow Explorer
 - Expose wakeup via REST-API
 - Update database indices to match workflow instance polling code
+- Add new configuration option `nflow.db.disable_batch_updates`
 
 **Details**
 - `nflow-engine`
@@ -19,6 +20,7 @@
   - Update database indices to match current workflow instance polling code.
   - Create indices for foreign keys in MS SQL database.
   - Fix create database scripts to work with empty database.
+  - Add `nflow.db.disable_batch_updates` (default `false`) configuration parameter to make it possible to force use of multiple updates even if batch updates are supported by the database.
   - Dependency updates:
     - reactor.netty 0.8.11.RELEASE
     - jackson 2.9.10

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -63,5 +63,6 @@ nflow.db.oracle.password=nflow
 nflow.db.max_pool_size=4
 nflow.db.idle_timeout_seconds=600
 nflow.db.create_on_startup=true
+nflow.db.disable_batch_updates=false
 
 nflow.definition.persist=true

--- a/nflow-engine/src/test/resources/junit.properties
+++ b/nflow-engine/src/test/resources/junit.properties
@@ -16,3 +16,4 @@ nflow.db.h2.password=
 nflow.db.max_pool_size=20
 nflow.db.idle_timeout_seconds=600
 nflow.db.create_on_startup=true
+nflow.db.disable_batch_updates=false


### PR DESCRIPTION
This makes it possible to revert to the multi update model even if the database needs it. This needs to be done to prevent MariaDB/Galera from having double executions.