### PR TITLE
Fix Explorer build tool dependency vulnerability warnings (from github)

### DIFF
--- a/nflow-explorer/Gruntfile.js
+++ b/nflow-explorer/Gruntfile.js
@@ -50,7 +50,7 @@ module.exports = function (grunt) {
       },
       sass: {
         files: ['<%= yeoman.src %>/styles/{,*/}*.{scss,sass}'],
-        tasks: ['sass:dist', 'autoprefixer']
+        tasks: ['sass:dist', 'postcss']
       },
       gruntfile: {
         files: ['Gruntfile.js']
@@ -157,9 +157,12 @@ module.exports = function (grunt) {
     },
 
     // Add vendor prefixed styles
-    autoprefixer: {
+    postcss: {
       options: {
-        browsers: ['last 1 version']
+        map: true,
+        processors: [
+          require('autoprefixer')
+        ]
       },
       dist: {
         files: [{
@@ -411,7 +414,7 @@ module.exports = function (grunt) {
       'clean:server',
       'wiredep',
       'concurrent:server',
-      'autoprefixer',
+      'postcss',
       'connect:livereload',
       'watch'
     ]);
@@ -425,7 +428,7 @@ module.exports = function (grunt) {
   grunt.registerTask('test', [
     'clean:server',
     'concurrent:test',
-    'autoprefixer',
+    'postcss',
     'connect:test',
     'karma'
   ]);
@@ -439,7 +442,7 @@ module.exports = function (grunt) {
     grunt.task.run([
       'clean:server',
       'concurrent:test',
-      'autoprefixer',
+      'postcss',
       'connect:test',
       'protractor'
     ]);
@@ -450,7 +453,7 @@ module.exports = function (grunt) {
     'wiredep',
     'useminPrepare',
     'concurrent:dist',
-    'autoprefixer',
+    'postcss',
     'concat',
     'ngAnnotate',
     'copy:dist',

--- a/nflow-explorer/Gruntfile.js
+++ b/nflow-explorer/Gruntfile.js
@@ -379,23 +379,6 @@ module.exports = function (grunt) {
       ]
     },
 
-    selenium_standalone: {
-      options: {
-        stopOnExit: true
-      },
-      seleniumTask: {
-        seleniumVersion: '2.53.0',
-        seleniumDownloadURL: 'http://selenium-release.storage.googleapis.com',
-        drivers: {
-          chrome: {
-            version: '2.24',
-            arch: process.arch,
-            baseURL: 'http://chromedriver.storage.googleapis.com'
-          }
-        }
-      }
-    },
-
     protractor: {
       options: {
         configFile: 'test/protractor.conf.js', // Default config file
@@ -458,8 +441,6 @@ module.exports = function (grunt) {
       'concurrent:test',
       'autoprefixer',
       'connect:test',
-      'selenium_standalone:seleniumTask:install',
-      'selenium_standalone:seleniumTask:start',
       'protractor'
     ]);
   });

--- a/nflow-explorer/README.md
+++ b/nflow-explorer/README.md
@@ -69,22 +69,4 @@ nflow-explorer/
 
 ## Running test
 
-### Unit tests
-
-```sh
-grunt test
-```
-
-### Integration tests:
-
-First install webdriver: 
-
-```sh 
-node_modules/protractor/bin/webdriver-manager update
-```
-
-Running tests
-
-```sh
-grunt itest
-```
+[See instructions](test/README.md)

--- a/nflow-explorer/package-lock.json
+++ b/nflow-explorer/package-lock.json
@@ -282,12 +282,6 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
-    "ansi-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-      "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-      "dev": true
-    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -507,16 +501,19 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "autoprefixer-core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
-      "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
+    "autoprefixer": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
+      "integrity": "sha512-8T5Y1C5Iyj6PgkPSFd0ODvK9DIleuPKUPYniNxybS47g2k2wFgLZ46lGQHlBuGKIAEV8fbCDfKCCRS1tvOgc3Q==",
       "dev": true,
       "requires": {
-        "browserslist": "~0.4.0",
-        "caniuse-db": "^1.0.30000214",
-        "num2fraction": "^1.1.0",
-        "postcss": "~4.1.12"
+        "browserslist": "^4.8.0",
+        "caniuse-lite": "^1.0.30001012",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.23",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "aws-sign2": {
@@ -1084,12 +1081,14 @@
       }
     },
     "browserslist": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
-      "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
       "dev": true,
       "requires": {
-        "caniuse-db": "^1.0.30000153"
+        "caniuse-lite": "^1.0.30001015",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.42"
       }
     },
     "browserstack": {
@@ -1232,10 +1231,10 @@
         "map-obj": "^1.0.0"
       }
     },
-    "caniuse-db": {
-      "version": "1.0.30000988",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000988.tgz",
-      "integrity": "sha512-P0JCbGJhL1tTTeF+ehckvXwtckRursLDbA/ETdAd8Yg1ROAGJ5OgYgMONW1zWW1+ZTB79d7ZeJiOHGreEGG1ew==",
+    "caniuse-lite": {
+      "version": "1.0.30001016",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
+      "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
       "dev": true
     },
     "caseless": {
@@ -2070,9 +2069,9 @@
       "dev": true
     },
     "diff": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz",
-      "integrity": "sha1-/Qeh8fiRUZ2ZBaTJqJ3PWnC2YDc=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dir-glob": {
@@ -2246,6 +2245,12 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
+    "electron-to-chromium": {
+      "version": "1.3.322",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+      "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+      "dev": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -2390,12 +2395,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
-      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -3472,45 +3471,6 @@
         }
       }
     },
-    "grunt-autoprefixer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
-      "integrity": "sha1-/kLiR7z6ucKSoSwGLa1PNb3pAsU=",
-      "dev": true,
-      "requires": {
-        "autoprefixer-core": "^5.1.7",
-        "chalk": "~1.0.0",
-        "diff": "~1.3.0",
-        "postcss": "^4.1.11"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-          "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.0.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^1.0.3",
-            "strip-ansi": "^2.0.1",
-            "supports-color": "^1.3.0"
-          }
-        },
-        "supports-color": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-          "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
-          "dev": true
-        }
-      }
-    },
     "grunt-cli": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.2.tgz",
@@ -3974,6 +3934,36 @@
         "ng-annotate": "^1.2.1"
       }
     },
+    "grunt-postcss": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.9.0.tgz",
+      "integrity": "sha512-lglLcVaoOIqH0sFv7RqwUKkEFGQwnlqyAKbatxZderwZGV1nDyKHN7gZS9LUiTx1t5GOvRBx0BEalHMyVwFAIA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.1.0",
+        "diff": "^3.0.0",
+        "postcss": "^6.0.11"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "grunt-protractor-runner": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/grunt-protractor-runner/-/grunt-protractor-runner-5.0.0.tgz",
@@ -4271,16 +4261,6 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-      "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^1.1.0",
-        "get-stdin": "^4.0.1"
       }
     },
     "has-binary2": {
@@ -6538,6 +6518,23 @@
         "websocket-stream": "^5.0.1"
       }
     },
+    "node-releases": {
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.43.tgz",
+      "integrity": "sha512-Rmfnj52WNhvr83MvuAWHEqXVoZXCcDQssSOffU4n4XOL9sPrP61mSZ88g25NqmABDvH7PiAlFCzoSCSdzA293w==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "node-sass": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
@@ -6649,6 +6646,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-url": {
@@ -7412,15 +7415,38 @@
       "dev": true
     },
     "postcss": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-      "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
+      "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
       "dev": true,
       "requires": {
-        "es6-promise": "~2.3.0",
-        "js-base64": "~2.1.8",
-        "source-map": "~0.4.2"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
+    },
+    "postcss-value-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -9243,15 +9269,6 @@
       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
       "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
       "dev": true
-    },
-    "strip-ansi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-      "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^1.0.0"
-      }
     },
     "strip-bom": {
       "version": "2.0.0",

--- a/nflow-explorer/package-lock.json
+++ b/nflow-explorer/package-lock.json
@@ -908,6 +908,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -1023,15 +1024,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
-      }
     },
     "bower": {
       "version": "1.8.8",
@@ -1670,15 +1662,6 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x"
       }
     },
     "css-select": {
@@ -3073,8 +3056,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -3167,24 +3149,6 @@
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
-      }
-    },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -4134,17 +4098,6 @@
       "integrity": "sha512-90s27H7FoCDcA8C8+R0GwC+ntYD3lG6S/jqcavWm3bn9RiJTmSfOvfbFa1PXx4NbBWuiGQMLfQTj/JvvqT5w6A==",
       "dev": true
     },
-    "grunt-selenium-standalone": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-selenium-standalone/-/grunt-selenium-standalone-1.0.1.tgz",
-      "integrity": "sha1-O4ZdrS4pnlu+/NgHZa1YRLA4pGQ=",
-      "dev": true,
-      "requires": {
-        "lodash.clonedeep": "^4.3.2",
-        "q": "^1.4.1",
-        "selenium-standalone": "^5.1.0"
-      }
-    },
     "grunt-svgmin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-6.0.0.tgz",
@@ -4430,28 +4383,10 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "homedir-polyfill": {
@@ -4974,25 +4909,6 @@
       "dev": true,
       "optional": true
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
-      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
-      "dev": true,
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -5082,12 +4998,6 @@
       "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
       "dev": true,
       "optional": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -5627,12 +5537,6 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -8382,269 +8286,118 @@
       }
     },
     "selenium-standalone": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-5.11.2.tgz",
-      "integrity": "sha1-ckzKpy+ybzcR4OIJieR4xBM9+EQ=",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.17.0.tgz",
+      "integrity": "sha512-5PSnDHwMiq+OCiAGlhwQ8BM9xuwFfvBOZ7Tfbw+ifkTnOy0PWbZmI1B9gPGuyGHpbQ/3J3CzIK7BYwrQ7EjtWQ==",
       "dev": true,
       "requires": {
-        "async": "1.2.1",
-        "commander": "2.6.0",
-        "lodash": "3.9.3",
-        "minimist": "1.1.0",
-        "mkdirp": "0.5.0",
-        "progress": "1.1.8",
-        "request": "2.79.0",
-        "tar-stream": "1.5.2",
-        "urijs": "1.16.1",
-        "which": "1.1.1",
-        "yauzl": "^2.5.0"
+        "async": "^2.6.2",
+        "commander": "^2.19.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.1.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "progress": "2.0.3",
+        "request": "2.88.0",
+        "tar-stream": "2.0.0",
+        "urijs": "^1.19.1",
+        "which": "^1.3.1",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
         "async": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "lodash": "^4.17.14"
           }
         },
-        "commander": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+        "bl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+          "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
-            "commander": {
-              "version": "2.20.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-              "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-              "dev": true
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
             }
           }
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "ms": "^2.1.1"
           }
         },
-        "is-absolute": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-          "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
-            "is-relative": "^0.1.0"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
-        },
-        "is-relative": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-          "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
-          "integrity": "sha1-zfIl6ImPhAolje1E/JF3Z3Cv3JM=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         },
         "tar-stream": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-          "integrity": "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.0.0.tgz",
+          "integrity": "sha512-n2vtsWshZOVr/SY4KtslPoUlyNh06I2SGgAOCZmquCEjlbV/LjY2CY80rDtdQRHFOYXNlgBDo6Fr3ww2CWPOtA==",
           "dev": true,
           "requires": {
-            "bl": "^1.0.0",
-            "end-of-stream": "^1.0.0",
-            "readable-stream": "^2.0.0",
-            "xtend": "^4.0.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "dev": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
-          "integrity": "sha1-nOUSRZlGFm4SwIPwjsBzOA/Iy7s=",
-          "dev": true,
-          "requires": {
-            "is-absolute": "^0.1.7"
+            "bl": "^2.2.0",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
           }
         }
       }
@@ -8985,15 +8738,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
       }
     },
     "socket.io": {
@@ -9498,12 +9242,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
       "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
-      "dev": true
-    },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
       "dev": true
     },
     "strip-ansi": {
@@ -10134,9 +9872,9 @@
       "dev": true
     },
     "urijs": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.16.1.tgz",
-      "integrity": "sha1-hZrTGJD1+VKHJ76J8ZMslPtHMeI=",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
+      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==",
       "dev": true
     },
     "urix": {

--- a/nflow-explorer/package.json
+++ b/nflow-explorer/package.json
@@ -63,6 +63,6 @@
   },
   "scripts": {
     "test": "grunt test",
-    "selenium": "selenium-standalone install && selenium-standalone start && grunt itest"
+    "selenium": "selenium-standalone install && selenium-standalone start"
   }
 }

--- a/nflow-explorer/package.json
+++ b/nflow-explorer/package.json
@@ -32,7 +32,6 @@
     "grunt-ng-annotate": "3.0.0",
     "grunt-protractor-runner": "5.0.0",
     "grunt-sass": "3.1.0",
-    "grunt-selenium-standalone": "1.0.1",
     "grunt-svgmin": "6.0.0",
     "grunt-targethtml": "0.2.6",
     "grunt-usemin": "3.1.1",
@@ -48,18 +47,20 @@
     "karma-spec-reporter": "0.0.32",
     "load-grunt-tasks": "5.1.0",
     "moment": "2.24.0",
+    "node-sass": "4.13.0",
     "phantomjs-prebuilt": "2.1.16",
     "protractor": "6.0.0",
     "protractor-http-mock": "0.10.0",
+    "selenium-standalone": "^6.17.0",
     "serve-static": "1.14.1",
     "sinon": "7.5.0",
-    "time-grunt": "2.0.0",
-    "node-sass": "4.13.0"
+    "time-grunt": "2.0.0"
   },
   "engines": {
     "node": ">=8.9.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "selenium": "selenium-standalone install && selenium-standalone start && grunt itest"
   }
 }

--- a/nflow-explorer/package.json
+++ b/nflow-explorer/package.json
@@ -2,6 +2,7 @@
   "name": "nflow-explorer",
   "version": "1.0.0",
   "license": "EUPL-1.1",
+  "browsers": "last 1 version",
   "dependencies": {
     "lodash": "4.17.15"
   },
@@ -10,10 +11,10 @@
     "url": "https://github.com/NitorCreations/nflow-explorer.git"
   },
   "devDependencies": {
+    "autoprefixer": "9.7.3",
     "bower": "1.8.8",
     "extend": ">=3.0.2",
     "grunt": "1.0.4",
-    "grunt-autoprefixer": "3.0.4",
     "grunt-cli": "1.3.2",
     "grunt-concurrent": "3.0.0",
     "grunt-contrib-clean": "2.0.0",
@@ -30,6 +31,7 @@
     "grunt-karma": "3.0.2",
     "grunt-newer": "1.3.0",
     "grunt-ng-annotate": "3.0.0",
+    "grunt-postcss": "0.9.0",
     "grunt-protractor-runner": "5.0.0",
     "grunt-sass": "3.1.0",
     "grunt-svgmin": "6.0.0",
@@ -51,7 +53,7 @@
     "phantomjs-prebuilt": "2.1.16",
     "protractor": "6.0.0",
     "protractor-http-mock": "0.10.0",
-    "selenium-standalone": "^6.17.0",
+    "selenium-standalone": "6.17.0",
     "serve-static": "1.14.1",
     "sinon": "7.5.0",
     "time-grunt": "2.0.0"

--- a/nflow-explorer/test/README.md
+++ b/nflow-explorer/test/README.md
@@ -10,8 +10,31 @@ $ grunt test
 ```
 
 ### Protractor tests
+
+Update webdriver:
 ```sh
 $ node_modules/protractor/bin/webdriver-manager update
+```
+
+Build nFlow in repository root (in order to run test backend):
+```sh
+$ mvn -DskipTests install
+```
+
+Start nFlow test backend in separate terminal (change version number in filename):
+```sh
+$ java -jar nflow-tests/target/nflow-tests-6.0.1-SNAPSHOT.jar
+```
+
+Start standalone Selenium in nflow-explorer:
+```sh
+$ npm run selenium
+```
+
+Note that the tests require also [nBank in AWS](https://bank.nflow.io/) to be running.
+
+To run protractor tests:
+```
 $ grunt itest
 ```
 To run protractor tests against distribution build:

--- a/nflow-explorer/test/it/endpointSelection.spec.js
+++ b/nflow-explorer/test/it/endpointSelection.spec.js
@@ -47,7 +47,7 @@ describe('endpoint selection', function () {
 
   describe('selecting nBank endpoint', function() {
     beforeEach(function() {
-      menu.toAbout();
+      menu.toDefinitions();
       menu.clickEndpointSelection();
       menu.selectEndpoint('nbank');
     });
@@ -56,7 +56,9 @@ describe('endpoint selection', function () {
       menu.clickEndpointSelection();
       menu.selectEndpoint('localhost');
 
-      browser.wait(element(by.id('workflowDefinitionsList')).isDisplayed);
+      var until = protractor.ExpectedConditions;
+      browser.wait(until.presenceOf(element(by.id('workflowDefinitionsList'))));
+
       expect(menu.selectedEndpoint()).toBe('local nflow instance');
       expect(frontPage.getDefinitions()).toContain('fibonacci');
     });

--- a/nflow-explorer/test/it/frontPage.spec.js
+++ b/nflow-explorer/test/it/frontPage.spec.js
@@ -13,7 +13,9 @@ describe('front page', function() {
   beforeEach(function() { frontPage.get(); });
 
   it('has list of workflow definitions', function() {
-    expect(frontPage.getDefinitions()).toEqual(_.map(fixture.wfs, 'name'));
+    _.forEach(fixture.wfs, function(wf) {
+      expect(frontPage.getDefinitions()).toContain(wf.name);
+    })
   });
 
   it('provides navigation to workflow definitions', function() {

--- a/nflow-explorer/test/it/pageobjects/searchPage.js
+++ b/nflow-explorer/test/it/pageobjects/searchPage.js
@@ -13,7 +13,7 @@ module.exports = function (spec) {
   spec.resultRows = $$('table#search-result tbody tr');
 
   that.get = function(type, state) {
-    var url = '/#/search';
+    var url = '/#!/search';
 
     var t = 'type=' + type;
     var s = 'state=' + state;

--- a/nflow-explorer/test/it/pageobjects/workflowDefinitionPage.js
+++ b/nflow-explorer/test/it/pageobjects/workflowDefinitionPage.js
@@ -10,7 +10,7 @@ module.exports = function (spec) {
   spec.instanceSearchByTypeLink = element(by.linkText('Search related workflow instances'));
 
   that.get = function (type) {
-    browser.get('/#/workflow-definition/' + type);
+    browser.get('/#!/workflow-definition/' + type);
     expect(that.isDisplayed()).toBeTruthy();
   };
 

--- a/nflow-explorer/test/it/pageobjects/workflowPage.js
+++ b/nflow-explorer/test/it/pageobjects/workflowPage.js
@@ -10,7 +10,7 @@ module.exports = function (spec) {
   spec.definitionLink = element(by.linkText('Go to workflow definition'));
 
   that.get = function (id) {
-    browser.get('/#/workflow/' + id);
+    browser.get('/#!/workflow/' + id);
     expect(that.isDisplayed()).toBeTruthy();
   };
 

--- a/nflow-explorer/test/protractor.conf.js
+++ b/nflow-explorer/test/protractor.conf.js
@@ -12,7 +12,7 @@ exports.config = {
     }
   },
 
-  // allows running individual files: grunt itest --suite frontPage,search
+  // allows running individual files: grunt itest --suite=frontPage,search
   suites: {
     endpointSelection: 'it/endpointSelection.spec.js',
     frontPage: 'it/frontPage.spec.js',


### PR DESCRIPTION
- migrate from grunt-autofixer to grunt-postcss (fixes diff-library vulnerability warning)
- migrate from grunt-selenium-standalone to direct usage of selenium-standalone when running Protractor tests (fixes hoek- and cryptiles-library vulnerability warning)
- fix rotten Protractor tests so that having any dependency to selenium makes any sense