### PR TITLE
Honor the includeCurrentStateVariables in the QueryWorkflowInstances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 **Highlights**
 - `nflow-engine`
   - Check that state variable value fits into the database column
+  - Start to honor the include-state-variables boolean in list workflow instance queries for the java api.
+    This is a bugfix that might affect existing code. The rest api is unaffected.
 
 **Details**
 - `nflow-engine`
   - Throw `StateVariableValueTooLongException` if a state variable value that does not fit into the database column is detected. Checked in `StateExecution.setVariable`, `StateExecution.addWorkflows`, `StateExecution.addChildWorkflows`, `WorkflowInstanceService.insertWorkflowInstance` and when creating a new instance via REST API. If the exception is thrown during state processing and not handled by the state implementation, nFlow engine will catch the exception and retry state processing after delay configured by property `nflow.executor.stateVariableValueTooLongRetryDelay.minutes` (default is 60).
+  - Fix honoring of include-state-variables boolean in list workflow instance queries for the java api. This caused major slowness when using Bulk workflows.
   - Dependency updates:
     - jetty 9.4.24.v20191120
     - junit4 4.13-rc-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 **Details**
 - `nflow-engine`
   - Throw `StateVariableValueTooLongException` if a state variable value that does not fit into the database column is detected. Checked in `StateExecution.setVariable`, `StateExecution.addWorkflows`, `StateExecution.addChildWorkflows`, `WorkflowInstanceService.insertWorkflowInstance` and when creating a new instance via REST API. If the exception is thrown during state processing and not handled by the state implementation, nFlow engine will catch the exception and retry state processing after delay configured by property `nflow.executor.stateVariableValueTooLongRetryDelay.minutes` (default is 60).
-  - Fix honoring of includeCurrentStateVariables boolean in list workflow instance queries for the java api. This caused major slowness when using Bulk workflows.
-    To preserve the existing (buggy) behaviour in incompatible way the default value in QueryWorkflowInstances. Builder was changed to true. The rest api is unaffected.
-    Especially in workflows with many children that use the getAllChildWorkflows method the performance impact can be high.
+  - Fix honoring of `includeCurrentStateVariables` flag in `WorkflowInstanceService.listWorkflowInstances`. This caused major slowness when using bulk workflows.
+    To preserve the existing (incorrect) default behaviour in backwards compatible way the default value in `QueryWorkflowInstances.Builder` is changed to `true`. The REST API is unaffected.
+    Especially in workflows with many children that use the `StateExecution.getAllChildWorkflows` method the performance impact can be high. Before 7.0.0 release, it is recommended to use `StateExecution.queryChildWorkflows(new QueryWorkflowInstances.Builder().setIncludeCurrentStateVariables(false).build())` if state variables are not needed.
   - Dependency updates:
     - jetty 9.4.24.v20191120
     - junit4 4.13-rc-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 **Highlights**
 - `nflow-engine`
   - Check that state variable value fits into the database column
-  - Start to honor the include-state-variables boolean in list workflow instance queries for the java api.
-    This is a bugfix that might affect existing code. The rest api is unaffected.
 
 **Details**
 - `nflow-engine`
   - Throw `StateVariableValueTooLongException` if a state variable value that does not fit into the database column is detected. Checked in `StateExecution.setVariable`, `StateExecution.addWorkflows`, `StateExecution.addChildWorkflows`, `WorkflowInstanceService.insertWorkflowInstance` and when creating a new instance via REST API. If the exception is thrown during state processing and not handled by the state implementation, nFlow engine will catch the exception and retry state processing after delay configured by property `nflow.executor.stateVariableValueTooLongRetryDelay.minutes` (default is 60).
-  - Fix honoring of include-state-variables boolean in list workflow instance queries for the java api. This caused major slowness when using Bulk workflows.
+  - Fix honoring of includeCurrentStateVariables boolean in list workflow instance queries for the java api. This caused major slowness when using Bulk workflows.
+    To preserve the existing (buggy) behaviour in incompatible way the default value in QueryWorkflowInstances. Builder was changed to true. The rest api is unaffected.
+    Especially in workflows with many children that use the getAllChildWorkflows method the performance impact can be high.
   - Dependency updates:
     - jetty 9.4.24.v20191120
     - junit4 4.13-rc-1

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -677,8 +677,10 @@ public class WorkflowInstanceDao {
     sql = sqlVariants.limit(sql, getMaxResults(query.maxResults));
     List<WorkflowInstance> ret = namedJdbc.query(sql, params, new WorkflowInstanceRowMapper()).stream()
         .map(WorkflowInstance.Builder::build).collect(toList());
-    for (WorkflowInstance instance : ret) {
-      fillState(instance);
+    if (query.includeCurrentStateVariables) {
+      for (WorkflowInstance instance : ret) {
+        fillState(instance);
+      }
     }
     if (query.includeActions) {
       for (WorkflowInstance instance : ret) {

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/BulkWorkflow.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/BulkWorkflow.java
@@ -91,6 +91,7 @@ public class BulkWorkflow extends WorkflowDefinition<BulkWorkflow.State> {
   }
 
   protected boolean splitWorkImpl(StateExecution execution, @SuppressWarnings("unused") JsonNode data) {
+    // TODO: change back to getAllChildWorkflows after it no longer returns state variables
     if (execution.queryChildWorkflows(new QueryWorkflowInstances.Builder().setIncludeCurrentStateVariables(false).build()).isEmpty()) {
       throw new RuntimeException("No child workflows found for workflow instance " + execution.getWorkflowInstanceId()
           + " - either add them before starting the parent or implement splitWorkflowImpl");
@@ -104,6 +105,7 @@ public class BulkWorkflow extends WorkflowDefinition<BulkWorkflow.State> {
 
   public NextAction waitForChildrenToFinish(StateExecution execution,
       @StateVar(value = VAR_CONCURRENCY, readOnly = true) int concurrency) {
+    // TODO: change back to getAllChildWorkflows after it no longer returns state variables
     List<WorkflowInstance> childWorkflows = execution.queryChildWorkflows(new QueryWorkflowInstances.Builder().setIncludeCurrentStateVariables(false).build());
     long completed = 0;
     long running = 0;

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/BulkWorkflow.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/BulkWorkflow.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
@@ -90,7 +91,7 @@ public class BulkWorkflow extends WorkflowDefinition<BulkWorkflow.State> {
   }
 
   protected boolean splitWorkImpl(StateExecution execution, @SuppressWarnings("unused") JsonNode data) {
-    if (execution.getAllChildWorkflows().isEmpty()) {
+    if (execution.queryChildWorkflows(new QueryWorkflowInstances.Builder().setIncludeCurrentStateVariables(false).build()).isEmpty()) {
       throw new RuntimeException("No child workflows found for workflow instance " + execution.getWorkflowInstanceId()
           + " - either add them before starting the parent or implement splitWorkflowImpl");
     }
@@ -103,7 +104,7 @@ public class BulkWorkflow extends WorkflowDefinition<BulkWorkflow.State> {
 
   public NextAction waitForChildrenToFinish(StateExecution execution,
       @StateVar(value = VAR_CONCURRENCY, readOnly = true) int concurrency) {
-    List<WorkflowInstance> childWorkflows = execution.getAllChildWorkflows();
+    List<WorkflowInstance> childWorkflows = execution.queryChildWorkflows(new QueryWorkflowInstances.Builder().setIncludeCurrentStateVariables(false).build());
     long completed = 0;
     long running = 0;
     for (WorkflowInstance child : childWorkflows) {

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
@@ -119,8 +119,8 @@ public interface StateExecution {
   List<WorkflowInstance> queryChildWorkflows(QueryWorkflowInstances query);
 
   /**
-   * Return all child workflows for current workflow.
-   * The state variables are returned until 7.x release when they must be explicitly requested using {@link #queryChildWorkflows(QueryWorkflowInstances)}.
+   * Return all child workflows with state variables for current workflow.
+   * TODO: Starting from 7.0.0 release, the state variables of child workflows will not be returned anymore. Use {@link #queryChildWorkflows(QueryWorkflowInstances)} instead to get the child workflows with state variables.
    * @return List of all child workflows.
    */
   List<WorkflowInstance> getAllChildWorkflows();

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
@@ -120,6 +120,7 @@ public interface StateExecution {
 
   /**
    * Return all child workflows for current workflow.
+   * The state variables are returned until 7.x release when they must be explicitly requested using {@link #queryChildWorkflows(QueryWorkflowInstances)}.
    * @return List of all child workflows.
    */
   List<WorkflowInstance> getAllChildWorkflows();

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/instance/QueryWorkflowInstances.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/instance/QueryWorkflowInstances.java
@@ -115,7 +115,8 @@ public class QueryWorkflowInstances extends ModelObject {
     String businessKey;
     String externalId;
     boolean includeActions;
-    boolean includeCurrentStateVariables;
+    /** Query implementation was ignoring this field in upto 6.x. Default will change to false in 7.x */
+    boolean includeCurrentStateVariables = true;
     boolean includeActionStateVariables;
     boolean includeChildWorkflows;
     Long maxResults;
@@ -235,6 +236,7 @@ public class QueryWorkflowInstances extends ModelObject {
 
     /**
      * Set whether current workflow state variables should be included in the results.
+     * Note: The default is true until 7.x where it will be changed to false.
      * @param includeCurrentStateVariables True to include state variables, false otherwise.
      * @return this.
      */

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/instance/QueryWorkflowInstances.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/instance/QueryWorkflowInstances.java
@@ -115,7 +115,7 @@ public class QueryWorkflowInstances extends ModelObject {
     String businessKey;
     String externalId;
     boolean includeActions;
-    /** Query implementation was ignoring this field in upto 6.x. Default will change to false in 7.x */
+    /** TODO: remove setting the default value to true in 7.0.0 release. */
     boolean includeCurrentStateVariables = true;
     boolean includeActionStateVariables;
     boolean includeChildWorkflows;
@@ -236,7 +236,7 @@ public class QueryWorkflowInstances extends ModelObject {
 
     /**
      * Set whether current workflow state variables should be included in the results.
-     * Note: The default is true until 7.x where it will be changed to false.
+     * The default is `true`. TODO: Change default to `false` in 7.0.0 release.
      * @param includeCurrentStateVariables True to include state variables, false otherwise.
      * @return this.
      */

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -148,7 +148,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     WorkflowInstance i1 = constructWorkflowInstanceBuilder().build();
     long id = dao.insertWorkflowInstance(i1);
     assertThat(id, not(equalTo(-1)));
-    QueryWorkflowInstances q = new QueryWorkflowInstances.Builder().build();
+    QueryWorkflowInstances q = new QueryWorkflowInstances.Builder().setIncludeCurrentStateVariables(false).build();
     List<WorkflowInstance> createdInstances = dao.queryWorkflowInstances(q);
     assertThat(createdInstances.size(), is(1));
     WorkflowInstance instance = createdInstances.get(0);

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -148,6 +148,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     WorkflowInstance i1 = constructWorkflowInstanceBuilder().build();
     long id = dao.insertWorkflowInstance(i1);
     assertThat(id, not(equalTo(-1)));
+    // TODO: remove setIncludeCurrentStateVariables(false) in 7.0.0 release
     QueryWorkflowInstances q = new QueryWorkflowInstances.Builder().setIncludeCurrentStateVariables(false).build();
     List<WorkflowInstance> createdInstances = dao.queryWorkflowInstances(q);
     assertThat(createdInstances.size(), is(1));

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -14,6 +14,7 @@ import static java.lang.Math.min;
 import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.apache.commons.lang3.StringUtils.repeat;
@@ -151,7 +152,8 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     List<WorkflowInstance> createdInstances = dao.queryWorkflowInstances(q);
     assertThat(createdInstances.size(), is(1));
     WorkflowInstance instance = createdInstances.get(0);
-    checkSameWorkflowInfo(i1, instance);
+    WorkflowInstance originalWithoutStateVariables = new WorkflowInstance.Builder(i1).setStateVariables(emptyMap()).build();
+    checkSameWorkflowInfo(originalWithoutStateVariables, instance);
     assertNull(instance.started);
   }
 

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
@@ -9,6 +9,8 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.joda.time.DateTime.now;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -132,6 +134,8 @@ public class StateExecutionImplTest {
     assertThat(actualQuery.parentWorkflowId, is(99L));
     assertThat(actualQuery.types, is(asList("a", "b")));
     assertThat(actualQuery.businessKey, is("123"));
+    // this will change to false in 7.x
+    assertThat(actualQuery.includeCurrentStateVariables, is(true));
   }
 
   @Test
@@ -143,8 +147,10 @@ public class StateExecutionImplTest {
     QueryWorkflowInstances actualQuery = queryCaptor.getValue();
 
     assertThat(actualQuery.parentWorkflowId, is(99L));
-    assertThat(actualQuery.types, is(Collections.<String>emptyList()));
+    assertThat(actualQuery.types, emptyCollectionOf(String.class));
     assertThat(actualQuery.businessKey, is(nullValue()));
+    // this will change to false in 7.x
+    assertThat(actualQuery.includeCurrentStateVariables, is(true));
   }
 
   @Test
@@ -165,7 +171,7 @@ public class StateExecutionImplTest {
     builder.putStateVariable("foo", data);
     WorkflowInstance i = builder.build();
     assertThat(i.nextActivation, is(notNullValue()));
-    assertThat(i.stateVariables.get("foo"), is(serializedData));
+    assertThat(i.stateVariables, hasEntry("foo", serializedData));
     verify(objectStringMapper).convertFromObject("foo", data);
   }
 

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
@@ -134,7 +134,7 @@ public class StateExecutionImplTest {
     assertThat(actualQuery.parentWorkflowId, is(99L));
     assertThat(actualQuery.types, is(asList("a", "b")));
     assertThat(actualQuery.businessKey, is("123"));
-    // this will change to false in 7.x
+    // TODO: change to `false` in 7.0.0 release
     assertThat(actualQuery.includeCurrentStateVariables, is(true));
   }
 
@@ -149,7 +149,7 @@ public class StateExecutionImplTest {
     assertThat(actualQuery.parentWorkflowId, is(99L));
     assertThat(actualQuery.types, emptyCollectionOf(String.class));
     assertThat(actualQuery.businessKey, is(nullValue()));
-    // this will change to false in 7.x
+    // TODO: change to `false` in 7.0.0 release
     assertThat(actualQuery.includeCurrentStateVariables, is(true));
   }
 

--- a/nflow-tests/src/main/java/io/nflow/tests/demo/workflow/FibonacciWorkflow.java
+++ b/nflow-tests/src/main/java/io/nflow/tests/demo/workflow/FibonacciWorkflow.java
@@ -95,7 +95,7 @@ public class FibonacciWorkflow extends WorkflowDefinition<FibonacciWorkflow.Stat
   public NextAction poll(StateExecution execution) {
     // get finished and failed child workflows
     QueryWorkflowInstances query = new QueryWorkflowInstances.Builder().addStatuses(WorkflowInstanceStatus.manual,
-        WorkflowInstanceStatus.finished).build();
+        WorkflowInstanceStatus.finished).setIncludeCurrentStateVariables(true).build();
     List<WorkflowInstance> finishedChildren = execution.queryChildWorkflows(query);
 
     if (finishedChildren.size() < execution.getAllChildWorkflows().size()) {

--- a/nflow-tests/src/test/java/io/nflow/tests/ChildWorkflowTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/ChildWorkflowTest.java
@@ -1,24 +1,22 @@
 package io.nflow.tests;
 
-import static java.time.Duration.ofSeconds;
-import static org.apache.cxf.jaxrs.client.WebClient.fromClient;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import io.nflow.rest.v1.msg.CreateWorkflowInstanceRequest;
 import io.nflow.rest.v1.msg.CreateWorkflowInstanceResponse;
 import io.nflow.rest.v1.msg.ListWorkflowInstanceResponse;
 import io.nflow.tests.demo.workflow.FibonacciWorkflow;
 import io.nflow.tests.extension.NflowServerConfig;
 import io.nflow.tests.extension.NflowServerExtension;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static java.time.Duration.ofSeconds;
+import static org.apache.cxf.jaxrs.client.WebClient.fromClient;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.notNullValue;
 
 @ExtendWith(NflowServerExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -48,8 +46,7 @@ public class ChildWorkflowTest extends AbstractNflowTest {
   public void checkFibonacciWorkflowComputesCorrectResult() {
     ListWorkflowInstanceResponse response = getWorkflowInstanceWithTimeout(workflowId, FibonacciWorkflow.State.done.name(),
         ofSeconds(30));
-    assertTrue(response.stateVariables.containsKey("result"));
-    assertEquals(8, response.stateVariables.get("result"));
+    assertThat(response.stateVariables, hasEntry("result", 8));
   }
 
 }


### PR DESCRIPTION
Noticed at customer where bulk workflow parent that had ~2k children spent 99% of time by calling `fillState` for each of the child instances - and the values where never needed for anything.