### PR TITLE
Tune workflow polling.

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/PollingBatchException.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/PollingBatchException.java
@@ -1,10 +1,10 @@
 package io.nflow.engine.internal.dao;
 
-public class PollingRaceConditionException extends RuntimeException {
+public class PollingBatchException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
-  public PollingRaceConditionException(String msg) {
+  public PollingBatchException(String msg) {
     super(msg, null, true, false);
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/PollingRaceConditionException.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/PollingRaceConditionException.java
@@ -1,0 +1,11 @@
+package io.nflow.engine.internal.dao;
+
+public class PollingRaceConditionException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public PollingRaceConditionException(String msg) {
+    super(msg, null, true, false);
+  }
+
+}

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -61,7 +61,6 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
@@ -575,8 +574,8 @@ public class WorkflowInstanceDao {
       return null;
     });
     if (ids.isEmpty()) {
-      logger.debug("Race condition in polling workflow instances detected. "
-              + "Multiple pollers using same name ({})", executorInfo.getExecutorGroup());
+      throw new PollingRaceConditionException("Race condition in polling workflow instances detected. "
+              + "Multiple pollers using same name (" + executorInfo.getExecutorGroup() + ")");
     }
     return ids;
   }

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -594,21 +594,14 @@ public class WorkflowInstanceDao {
      List<Object[]> batchArgs = new ArrayList<>(instances.size());
      for (OptimisticLockKey instance : instances) {
        batchArgs.add(new Object[] { instance.id, sqlVariants.tuneTimestampForDb(instance.modified) });
-       ids.add(instance.id);
      }
      int[] updateStatuses = jdbc
              .batchUpdate(updateInstanceForExecutionQuery() + " where id = ? and modified = ? and executor_id is null", batchArgs);
-     Iterator<Long> idIt = ids.iterator();
-     for (int status : updateStatuses) {
-       idIt.next();
+     for (int i = 0; i<updateStatuses.length; ++i) {
+       int status = updateStatuses[i];
        if (status == 1) {
-         continue;
-       }
-       if (status == 0) {
-         idIt.remove();
-         continue;
-       }
-       if (status < 0) {
+         ids.add(instances.get(i).id);
+       } else if (status != 0) {
          disableBatchUpdates = true;
          throw new PollingBatchException("Database was unable to provide information about affected rows in a batch. Disabling batch usage.");
        }

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.nflow.engine.internal.dao.ExecutorDao;
 import io.nflow.engine.internal.dao.PollingBatchException;
+import io.nflow.engine.internal.dao.PollingRaceConditionException;
 import io.nflow.engine.internal.dao.WorkflowInstanceDao;
 import io.nflow.engine.internal.util.PeriodicLogger;
 import io.nflow.engine.service.WorkflowDefinitionService;
@@ -85,6 +86,9 @@ public class WorkflowDispatcher implements Runnable {
               }
               dispatch(getNextInstanceIds());
             }
+          } catch (PollingRaceConditionException pex) {
+            logger.debug(pex.getMessage());
+            sleep(true);
           } catch (PollingBatchException pex) {
             logger.warn(pex.getMessage());
           } catch (@SuppressWarnings("unused") InterruptedException dropThrough) {
@@ -165,7 +169,7 @@ public class WorkflowDispatcher implements Runnable {
   private void sleep(boolean randomize) {
     try {
       if (randomize) {
-        Thread.sleep((long) (sleepTimeMillis * rand.nextDouble()));
+        Thread.sleep((long) (sleepTimeMillis * rand.nextFloat()));
       } else {
         Thread.sleep(sleepTimeMillis);
       }

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.nflow.engine.internal.dao.ExecutorDao;
-import io.nflow.engine.internal.dao.PollingRaceConditionException;
+import io.nflow.engine.internal.dao.PollingBatchException;
 import io.nflow.engine.internal.dao.WorkflowInstanceDao;
 import io.nflow.engine.internal.util.PeriodicLogger;
 import io.nflow.engine.service.WorkflowDefinitionService;
@@ -85,9 +85,8 @@ public class WorkflowDispatcher implements Runnable {
               }
               dispatch(getNextInstanceIds());
             }
-          } catch (PollingRaceConditionException pex) {
-            logger.info(pex.getMessage());
-            sleep(true);
+          } catch (PollingBatchException pex) {
+            logger.warn(pex.getMessage());
           } catch (@SuppressWarnings("unused") InterruptedException dropThrough) {
           } catch (Exception e) {
             logger.error("Exception in executing dispatcher - retrying after sleep period (" + e.getMessage() + ")", e);

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -701,6 +701,25 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
   }
 
   @Test
+  public void pollNextWorkflowInstancesWithPartialRaceCondition() throws InterruptedException {
+    int batchSize = 100;
+    for (int i = 0; i < batchSize; i++) {
+      WorkflowInstance instance = constructWorkflowInstanceBuilder().setNextActivation(now().minusMinutes(1))
+          .setExecutorGroup("junit").build();
+      dao.insertWorkflowInstance(instance);
+    }
+    Poller[] pollers = new Poller[] { new Poller(dao, batchSize), new Poller(dao, batchSize) };
+    Thread[] threads = new Thread[] { new Thread(pollers[0]), new Thread(pollers[1]) };
+    threads[0].start();
+    threads[1].start();
+    threads[0].join();
+    threads[1].join();
+    assertThat(pollers[0].returnSize + pollers[1].returnSize, is(batchSize));
+    assertTrue(pollers[0].detectedRaceCondition || pollers[1].detectedRaceCondition
+        || (pollers[0].returnSize < batchSize && pollers[1].returnSize < batchSize), "Race condition should happen");
+  }
+
+  @Test
   public void wakesUpSleepingWorkflow() {
     WorkflowInstance i1 = constructWorkflowInstanceBuilder().setNextActivation(null).build();
     long id = dao.insertWorkflowInstance(i1);
@@ -999,7 +1018,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     public void run() {
       try {
         returnSize = min(returnSize, dao.pollNextWorkflowInstanceIds(batchSize).size());
-      } catch (PollingBatchException ex) {
+      } catch (PollingRaceConditionException ex) {
         ex.printStackTrace();
         returnSize = 0;
         detectedRaceCondition = ex.getMessage().startsWith("Race condition");

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -1027,7 +1027,8 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
       } catch (PollingRaceConditionException ex) {
         ex.printStackTrace();
         returnSize = 0;
-        detectedRaceCondition = ex.getMessage().startsWith("Race condition");
+        detectedRaceCondition = ex.getMessage().equals(
+            "None of the workflow instances selected for processing were successfully reserved for this executor, trying again later.");
       }
     }
   }

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -710,15 +710,15 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
       dao.insertWorkflowInstance(instance);
     }
     Poller[] pollers = new Poller[] { new Poller(dao, batchSize), new Poller(dao, batchSize) };
-    for (int i=0; i<10; ++i) {
-      Thread[] threads = new Thread[]{new Thread(pollers[0]), new Thread(pollers[1])};
+    for (int i = 0; i < 10; ++i) {
+      Thread[] threads = new Thread[] { new Thread(pollers[0]), new Thread(pollers[1]) };
       threads[0].start();
       threads[1].start();
       threads[0].join();
       threads[1].join();
       assertThat(pollers[0].returnSize + pollers[1].returnSize, is(batchSize));
       if (pollers[0].detectedRaceCondition || pollers[1].detectedRaceCondition
-              || (pollers[0].returnSize < batchSize && pollers[1].returnSize < batchSize)) {
+          || (pollers[0].returnSize < batchSize && pollers[1].returnSize < batchSize)) {
         return;
       }
     }

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -1027,8 +1027,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
       } catch (PollingRaceConditionException ex) {
         ex.printStackTrace();
         returnSize = 0;
-        detectedRaceCondition = ex.getMessage().equals(
-            "None of the workflow instances selected for processing were successfully reserved for this executor, trying again later.");
+        detectedRaceCondition = true;
       }
     }
   }

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -709,14 +710,19 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
       dao.insertWorkflowInstance(instance);
     }
     Poller[] pollers = new Poller[] { new Poller(dao, batchSize), new Poller(dao, batchSize) };
-    Thread[] threads = new Thread[] { new Thread(pollers[0]), new Thread(pollers[1]) };
-    threads[0].start();
-    threads[1].start();
-    threads[0].join();
-    threads[1].join();
-    assertThat(pollers[0].returnSize + pollers[1].returnSize, is(batchSize));
-    assertTrue(pollers[0].detectedRaceCondition || pollers[1].detectedRaceCondition
-        || (pollers[0].returnSize < batchSize && pollers[1].returnSize < batchSize), "Race condition should happen");
+    for (int i=0; i<10; ++i) {
+      Thread[] threads = new Thread[]{new Thread(pollers[0]), new Thread(pollers[1])};
+      threads[0].start();
+      threads[1].start();
+      threads[0].join();
+      threads[1].join();
+      assertThat(pollers[0].returnSize + pollers[1].returnSize, is(batchSize));
+      if (pollers[0].detectedRaceCondition || pollers[1].detectedRaceCondition
+              || (pollers[0].returnSize < batchSize && pollers[1].returnSize < batchSize)) {
+        return;
+      }
+    }
+    fail("Race condition should happen");
   }
 
   @Test


### PR DESCRIPTION
- Fetch optimistic locked list of workflow instance ids in separate transaction from the modify phase. This should reduce the risk of deadlocks in databases.
- Also rework code so that if batch returns unsupported values we switch to non-batch usage.