### PR TITLE
Stream results out of rest api. 

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
@@ -7,10 +7,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -49,7 +51,8 @@ public class WorkflowInstanceService {
    * @param id Workflow instance id.
    * @param includes Set of properties to be loaded.
    * @param maxActions Maximum number of actions to be loaded.
-   * @return The workflow instance, or null if not found.
+   * @return The workflow instance.
+   * @throws EmptyResultDataAccessException If workflow instance is not found.
    */
   public WorkflowInstance getWorkflowInstance(long id, Set<WorkflowInstanceInclude> includes, Long maxActions) {
     return workflowInstanceDao.getWorkflowInstance(id, includes, maxActions);
@@ -124,6 +127,15 @@ public class WorkflowInstanceService {
    */
   public Collection<WorkflowInstance> listWorkflowInstances(QueryWorkflowInstances query) {
     return workflowInstanceDao.queryWorkflowInstances(query);
+  }
+
+  /**
+   * Return workflow instances matching the given query.
+   * @param query The query parameters.
+   * @return Matching workflow instances as Stream. The stream does not need to be closed.
+   */
+  public Stream<WorkflowInstance> listWorkflowInstancesAsStream(QueryWorkflowInstances query) {
+    return workflowInstanceDao.queryWorkflowInstancesAsStream(query);
   }
 
   /**

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -56,6 +56,7 @@ import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.core.env.Environment;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -104,6 +105,13 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     assertThat(i2.created, notNullValue());
     assertThat(i2.modified, notNullValue());
     checkSameWorkflowInfo(i1, i2);
+  }
+
+  @Test
+  public void queryNonExistingWorkflowThrowsException() {
+    assertThrows(EmptyResultDataAccessException.class, () ->
+      dao.getWorkflowInstance(-42, emptySet(), null)
+    );
   }
 
   @Test

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
@@ -130,7 +130,7 @@ public abstract class ResourceBase {
     return workflowInstances.updateWorkflowInstance(instance, action);
   }
 
-  public Collection<ListWorkflowInstanceResponse> listWorkflowInstances(final List<Long> ids, final List<String> types,
+  public Stream<ListWorkflowInstanceResponse> listWorkflowInstances(final List<Long> ids, final List<String> types,
       final Long parentWorkflowId, final Long parentActionId, final List<String> states,
       final List<WorkflowInstanceStatus> statuses, final String businessKey, final String externalId, final String include,
       final Long maxResults, final Long maxActions, final WorkflowInstanceService workflowInstances,
@@ -151,13 +151,9 @@ public abstract class ResourceBase {
         .setMaxResults(maxResults) //
         .setMaxActions(maxActions) //
         .setIncludeChildWorkflows(includeStrings.contains(childWorkflows)).build();
-    Collection<WorkflowInstance> instances = workflowInstances.listWorkflowInstances(q);
-    List<ListWorkflowInstanceResponse> resp = new ArrayList<>();
+    Stream<WorkflowInstance> instances = workflowInstances.listWorkflowInstancesAsStream(q);
     Set<WorkflowInstanceInclude> parseIncludeEnums = parseIncludeEnums(include);
-    for (WorkflowInstance instance : instances) {
-      resp.add(listWorkflowConverter.convert(instance, parseIncludeEnums));
-    }
-    return resp;
+    return instances.map(instance -> listWorkflowConverter.convert(instance, parseIncludeEnums));
   }
 
   private Set<WorkflowInstanceInclude> parseIncludeEnums(String include) {

--- a/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
+++ b/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
@@ -12,9 +12,9 @@ import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -129,7 +129,7 @@ public class WorkflowInstanceResource extends ResourceBase {
 
   @GET
   @ApiOperation(value = "List workflow instances", response = ListWorkflowInstanceResponse.class, responseContainer = "List")
-  public Collection<ListWorkflowInstanceResponse> listWorkflowInstances(
+  public Iterator<ListWorkflowInstanceResponse> listWorkflowInstances(
       @QueryParam("id") @ApiParam("Internal id of workflow instance") List<Long> ids,
       @QueryParam("type") @ApiParam("Workflow definition type of workflow instance") List<String> types,
       @QueryParam("parentWorkflowId") @ApiParam("Id of parent workflow instance") Long parentWorkflowId,
@@ -143,7 +143,7 @@ public class WorkflowInstanceResource extends ResourceBase {
       @QueryParam("maxActions") @ApiParam("Maximum number of actions returned for each workflow instance") Long maxActions) {
     return super.listWorkflowInstances(ids, types, parentWorkflowId, parentActionId, states,
         statuses, businessKey, externalId, include, maxResults, maxActions,
-        workflowInstances, listWorkflowConverter);
+        workflowInstances, listWorkflowConverter).iterator();
   }
 
   @PUT

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
@@ -182,7 +182,7 @@ public class WorkflowInstanceResourceTest {
   public void listWorkflowInstancesWorks() {
     resource.listWorkflowInstances(asList(42L), asList("type"), 99L, 88L, asList("state"),
         asList(WorkflowInstanceStatus.created), "businessKey", "externalId", "", null, null);
-    verify(workflowInstances).listWorkflowInstances((QueryWorkflowInstances) argThat(allOf(
+    verify(workflowInstances).listWorkflowInstancesAsStream((QueryWorkflowInstances) argThat(allOf(
         hasField("ids", contains(42L)),
         hasField("types", contains("type")),
         hasField("parentWorkflowId", is(99L)),
@@ -204,7 +204,7 @@ public class WorkflowInstanceResourceTest {
     resource.listWorkflowInstances(asList(42L), asList("type"), 99L, 88L, asList("state"),
         asList(WorkflowInstanceStatus.created, WorkflowInstanceStatus.executing),
         "businessKey", "externalId", "actions,currentStateVariables,actionStateVariables,childWorkflows", 1L, 1L);
-    verify(workflowInstances).listWorkflowInstances((QueryWorkflowInstances) argThat(allOf(
+    verify(workflowInstances).listWorkflowInstancesAsStream((QueryWorkflowInstances) argThat(allOf(
         hasField("ids", contains(42L)),
         hasField("types", contains("type")),
         hasField("parentWorkflowId", is(99L)),

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
@@ -12,9 +12,9 @@ import static org.springframework.http.ResponseEntity.ok;
 import static org.springframework.http.ResponseEntity.status;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -115,7 +115,7 @@ public class WorkflowInstanceResource extends ResourceBase {
 
   @GetMapping
   @ApiOperation(value = "List workflow instances", response = ListWorkflowInstanceResponse.class, responseContainer = "List")
-  public Collection<ListWorkflowInstanceResponse> listWorkflowInstances(
+  public Iterator<ListWorkflowInstanceResponse> listWorkflowInstances(
       @RequestParam(value = "id", defaultValue = "") @ApiParam("Internal id of workflow instance") List<Long> ids,
       @RequestParam(value = "type", defaultValue = "") @ApiParam("Workflow definition type of workflow instance") List<String> types,
       @RequestParam(value = "parentWorkflowId", required = false) @ApiParam("Id of parent workflow instance") Long parentWorkflowId,
@@ -128,7 +128,7 @@ public class WorkflowInstanceResource extends ResourceBase {
       @RequestParam(value = "maxResults", required = false) @ApiParam("Maximum number of workflow instances to be returned") Long maxResults,
       @RequestParam(value = "maxActions", required = false) @ApiParam("Maximum number of actions returned for each workflow instance") Long maxActions) {
     return super.listWorkflowInstances(ids, types, parentWorkflowId, parentActionId, states, statuses, businessKey, externalId,
-        include, maxResults, maxActions, this.workflowInstances, this.listWorkflowConverter);
+        include, maxResults, maxActions, this.workflowInstances, this.listWorkflowConverter).iterator();
   }
 
   @PutMapping(path = "/{id}/signal", consumes = APPLICATION_JSON_VALUE)


### PR DESCRIPTION
The main table query is still done synchronously, but additional queries are done on the stream lowering latency.
Should help with explorer UI, especially if it is later updated to process results lines as they arrive.