### PR TITLE
Make an error message more informative by adding the instance id

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
@@ -124,7 +124,7 @@ class WorkflowStateProcessor implements Runnable {
           logger.error("Failed to process workflow instance and shutdown requested", ex);
           break;
         }
-        logger.error("Failed to process workflow instance, retrying after {} seconds", stateProcessingRetryDelay, ex);
+        logger.error("Failed to process workflow instance {}, retrying after {} seconds", instanceId, stateProcessingRetryDelay, ex);
         sleepIgnoreInterrupted(stateProcessingRetryDelay);
       }
     }


### PR DESCRIPTION
When this error happens, the instance id is of interest to anyone trying to debug the issue.