### PR TITLE
Use dedicated thread pool for blocking database access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 **Highlights**
 
+- `nflow-rest-api-spring-web` and `nflow-netty`
+  - Change REST API calls to use a dedicated thread pool for all blocking database operations to avoid blocking the netty EventLoop thread.
+
 **Details**
 
 - `nflow-engine`
@@ -31,6 +34,9 @@
     - http-proxy 1.18.1
     - ini 1.3.7
     - bl 1.2.3
+- nflow-rest-api-spring-web
+  - Change deendency from spring-web to spring-webflux to be able to use Project Reactor's types.
+  - Introduce a thread pool in SchedulerService and wrap all blocking database calls in the REST API to it.
 
 ## 7.2.0 (2020-04-27)
 

--- a/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
+++ b/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
@@ -3,6 +3,7 @@ package io.nflow.netty;
 import static io.nflow.rest.v1.ResourcePaths.NFLOW_WORKFLOW_DEFINITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -58,7 +59,7 @@ public class StartNflowTest {
     ClientResponse response = client.get().uri(restApiPrefix + NFLOW_WORKFLOW_DEFINITION_PATH).exchange().block();
     assertEquals(HttpStatus.OK, response.statusCode());
     JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
-    assertEquals(responseBody.isArray(), true);
+    assertTrue(responseBody.isArray());
   }
 
 }

--- a/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
+++ b/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
@@ -1,5 +1,6 @@
 package io.nflow.netty;
 
+import static io.nflow.rest.v1.ResourcePaths.NFLOW_WORKFLOW_DEFINITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -10,6 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ApplicationContextEvent;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class StartNflowTest {
 
@@ -28,18 +36,29 @@ public class StartNflowTest {
         .registerSpringClasspathPropertySource("external.properties")
         .registerSpringApplicationListener(testListener);
     Map<String, Object> properties = new HashMap<>();
-    properties.put("nflow.db.create_on_startup", false);
+    String restApiPrefix = "nflow/api";
+    properties.put("nflow.db.create_on_startup", true);
     properties.put("nflow.autostart", false);
-    properties.put("nflow.autoinit", false);
+    properties.put("nflow.autoinit", true);
+    properties.put("nflow.rest.path.prefix", restApiPrefix);
+
     ApplicationContext ctx = startNflow.startNetty(7500, "local", "", properties);
 
     assertNotNull(testListener.applicationContextEvent);
     assertEquals("7500", ctx.getEnvironment().getProperty("port"));
     assertEquals("local", ctx.getEnvironment().getProperty("env"));
     assertEquals("externallyDefinedExecutorGroup", ctx.getEnvironment().getProperty("nflow.executor.group"));
-    assertEquals("false", ctx.getEnvironment().getProperty("nflow.db.create_on_startup"));
+    assertEquals("true", ctx.getEnvironment().getProperty("nflow.db.create_on_startup"));
     assertEquals("false", ctx.getEnvironment().getProperty("nflow.autostart"));
-    assertEquals("false", ctx.getEnvironment().getProperty("nflow.autoinit"));
+    assertEquals("true", ctx.getEnvironment().getProperty("nflow.autoinit"));
+
+    // Smoke test here also the netty REST API by fetching workflow definitions
+    WebClient client = WebClient.builder().baseUrl("http://localhost:7500")
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).build();
+    ClientResponse response = client.get().uri(restApiPrefix + NFLOW_WORKFLOW_DEFINITION_PATH).exchange().block();
+    assertEquals(HttpStatus.OK, response.statusCode());
+    JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
+    assertEquals(responseBody.isArray(), true);
   }
 
 }

--- a/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
+++ b/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
@@ -4,6 +4,7 @@ import static io.nflow.rest.v1.ResourcePaths.NFLOW_WORKFLOW_DEFINITION_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.http.HttpStatus.OK;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,9 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ApplicationContextEvent;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -53,11 +51,13 @@ public class StartNflowTest {
     assertEquals("false", ctx.getEnvironment().getProperty("nflow.autostart"));
     assertEquals("true", ctx.getEnvironment().getProperty("nflow.autoinit"));
 
-    // Smoke test here also the netty REST API by fetching workflow definitions
-    WebClient client = WebClient.builder().baseUrl("http://localhost:7500")
-        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).build();
+    smokeTestRestApi(restApiPrefix);
+  }
+
+  private void smokeTestRestApi(String restApiPrefix) {
+    WebClient client = WebClient.builder().baseUrl("http://localhost:7500").build();
     ClientResponse response = client.get().uri(restApiPrefix + NFLOW_WORKFLOW_DEFINITION_PATH).exchange().block();
-    assertEquals(HttpStatus.OK, response.statusCode());
+    assertEquals(OK, response.statusCode());
     JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
     assertTrue(responseBody.isArray());
   }

--- a/nflow-rest-api-spring-web/pom.xml
+++ b/nflow-rest-api-spring-web/pom.xml
@@ -24,7 +24,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
+      <artifactId>spring-webflux</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
@@ -1,0 +1,44 @@
+package io.nflow.rest.config.springweb;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+
+import javax.inject.Inject;
+
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import org.slf4j.Logger;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Service to hold a Webflux Scheduler in order to make blocking calls.
+ */
+@Service
+public class SchedulerService {
+
+  private static final Logger logger = getLogger(SchedulerService.class);
+  private Scheduler scheduler;
+  private WorkflowInstanceExecutor workflowInstanceExecutor;
+
+  @Inject
+  public SchedulerService(WorkflowInstanceExecutor workflowInstanceExecutor, Environment env) {
+    int dbPoolSize = env.getProperty("nflow.db.max_pool_size", Integer.class);
+    int dispatcherCount = workflowInstanceExecutor.getThreadCount();
+    int threadPoolSize = Math.max(dbPoolSize - dispatcherCount, 2);
+    logger.info("Initializing REST API thread pool size to {}", threadPoolSize);
+    this.scheduler = Schedulers.fromExecutor(
+        Executors.newFixedThreadPool(threadPoolSize));
+  }
+
+  public <T> Mono<T> wrapBlocking(Callable<T> callable) {
+    return Mono.fromCallable(callable).subscribeOn(this.scheduler);
+  }
+}

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
@@ -1,22 +1,22 @@
 package io.nflow.rest.config.springweb;
 
+import static java.lang.Math.max;
 import static org.slf4j.LoggerFactory.getLogger;
-
-import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
+import static reactor.core.publisher.Mono.fromCallable;
+import static reactor.core.scheduler.Schedulers.fromExecutor;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
-import org.slf4j.Logger;
-
+import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 
 /**
  * Service to hold a Webflux Scheduler in order to make blocking calls.
@@ -25,19 +25,19 @@ import reactor.core.scheduler.Schedulers;
 public class SchedulerService {
 
   private static final Logger logger = getLogger(SchedulerService.class);
-  private Scheduler scheduler;
+  private final Scheduler scheduler;
   private WorkflowInstanceExecutor workflowInstanceExecutor;
 
   @Inject
   public SchedulerService(WorkflowInstanceExecutor workflowInstanceExecutor, Environment env) {
     int dbPoolSize = env.getProperty("nflow.db.max_pool_size", Integer.class);
     int dispatcherCount = workflowInstanceExecutor.getThreadCount();
-    int threadPoolSize = Math.max(dbPoolSize - dispatcherCount, 2);
+    int threadPoolSize = max(dbPoolSize - dispatcherCount, 2);
     logger.info("Initializing REST API thread pool size to {}", threadPoolSize);
-    this.scheduler = Schedulers.fromExecutor(Executors.newFixedThreadPool(threadPoolSize));
+    this.scheduler = fromExecutor(Executors.newFixedThreadPool(threadPoolSize));
   }
 
   public <T> Mono<T> wrapBlocking(Callable<T> callable) {
-    return Mono.fromCallable(callable).subscribeOn(this.scheduler);
+    return fromCallable(callable).subscribeOn(this.scheduler);
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
@@ -26,7 +26,6 @@ public class SchedulerService {
 
   private static final Logger logger = getLogger(SchedulerService.class);
   private final Scheduler scheduler;
-  private WorkflowInstanceExecutor workflowInstanceExecutor;
 
   @Inject
   public SchedulerService(WorkflowInstanceExecutor workflowInstanceExecutor, Environment env) {

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
@@ -34,8 +34,7 @@ public class SchedulerService {
     int dispatcherCount = workflowInstanceExecutor.getThreadCount();
     int threadPoolSize = Math.max(dbPoolSize - dispatcherCount, 2);
     logger.info("Initializing REST API thread pool size to {}", threadPoolSize);
-    this.scheduler = Schedulers.fromExecutor(
-        Executors.newFixedThreadPool(threadPoolSize));
+    this.scheduler = Schedulers.fromExecutor(Executors.newFixedThreadPool(threadPoolSize));
   }
 
   public <T> Mono<T> wrapBlocking(Callable<T> callable) {

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/config/springweb/SchedulerService.java
@@ -37,7 +37,7 @@ public class SchedulerService {
     this.scheduler = fromExecutor(Executors.newFixedThreadPool(threadPoolSize));
   }
 
-  public <T> Mono<T> wrapBlocking(Callable<T> callable) {
+  public <T> Mono<T> callAsync(Callable<T> callable) {
     return fromCallable(callable).subscribeOn(this.scheduler);
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/MaintenanceResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/MaintenanceResource.java
@@ -46,11 +46,11 @@ public class MaintenanceResource extends SpringWebResource {
   @ApiOperation(value = "Do maintenance on old workflow instances synchronously", response = MaintenanceResponse.class)
   public Mono<ResponseEntity<?>> cleanupWorkflows(
       @RequestBody @ApiParam(value = "Parameters for the maintenance process", required = true) MaintenanceRequest request) {
-    return handleExceptions(() -> {
+    return handleExceptions(() -> wrapBlocking(() -> {
       MaintenanceConfiguration configuration = converter.convert(request);
       MaintenanceResults results = maintenanceService.cleanupWorkflows(configuration);
-      return wrapBlocking(() -> ok(converter.convert(results)));
-    });
+      return ok(converter.convert(results));
+    }));
   }
 
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
@@ -1,6 +1,7 @@
 package io.nflow.rest.v1.springweb;
 
 import static org.springframework.http.ResponseEntity.status;
+import static reactor.core.publisher.Mono.just;
 
 import java.util.function.Supplier;
 
@@ -8,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 
 import io.nflow.rest.v1.ResourceBase;
 import io.nflow.rest.v1.msg.ErrorResponse;
-
 import reactor.core.publisher.Mono;
 
 public abstract class SpringWebResource extends ResourceBase {
@@ -18,6 +18,6 @@ public abstract class SpringWebResource extends ResourceBase {
   }
 
   private Mono<ResponseEntity<?>> toErrorResponse(int statusCode, ErrorResponse body) {
-    return Mono.just(status(statusCode).body(body));
+    return just(status(statusCode).body(body));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
@@ -3,15 +3,27 @@ package io.nflow.rest.v1.springweb;
 import static org.springframework.http.ResponseEntity.status;
 import static reactor.core.publisher.Mono.just;
 
+import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import org.springframework.http.ResponseEntity;
 
+import io.nflow.rest.config.springweb.SchedulerService;
 import io.nflow.rest.v1.ResourceBase;
 import io.nflow.rest.v1.msg.ErrorResponse;
 import reactor.core.publisher.Mono;
 
 public abstract class SpringWebResource extends ResourceBase {
+
+  private final SchedulerService scheduler;
+
+  protected SpringWebResource(SchedulerService scheduler) {
+    this.scheduler = scheduler;
+  }
+
+  protected Mono<ResponseEntity<?>> wrapBlocking(Callable<ResponseEntity<?>> callable) {
+    return scheduler.callAsync(callable);
+  }
 
   protected Mono<ResponseEntity<?>> handleExceptions(Supplier<Mono<ResponseEntity<?>>> response) {
     return handleExceptions(response::get, this::toErrorResponse);

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
@@ -9,13 +9,15 @@ import org.springframework.http.ResponseEntity;
 import io.nflow.rest.v1.ResourceBase;
 import io.nflow.rest.v1.msg.ErrorResponse;
 
+import reactor.core.publisher.Mono;
+
 public abstract class SpringWebResource extends ResourceBase {
 
-  protected ResponseEntity<?> handleExceptions(Supplier<ResponseEntity<?>> response) {
+  protected Mono<ResponseEntity<?>> handleExceptions(Supplier<Mono<ResponseEntity<?>>> response) {
     return handleExceptions(response::get, this::toErrorResponse);
   }
 
-  private ResponseEntity<?> toErrorResponse(int statusCode, ErrorResponse body) {
-    return status(statusCode).body(body);
+  private Mono<ResponseEntity<?>> toErrorResponse(int statusCode, ErrorResponse body) {
+    return Mono.just(status(statusCode).body(body));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/StatisticsResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/StatisticsResource.java
@@ -24,7 +24,6 @@ import io.nflow.rest.v1.msg.WorkflowDefinitionStatisticsResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -33,18 +32,21 @@ import reactor.core.publisher.Mono;
 @Component
 public class StatisticsResource extends SpringWebResource {
 
+  private final StatisticsService statisticsService;
+  private final StatisticsConverter statisticsConverter;
+
   @Inject
-  private StatisticsService statisticsService;
-  @Inject
-  private StatisticsConverter statisticsConverter;
-  @Inject
-  private SchedulerService scheduler;
+  public StatisticsResource(SchedulerService scheduler, StatisticsConverter statisticsConverter,
+      StatisticsService statisticsService) {
+    super(scheduler);
+    this.statisticsService = statisticsService;
+    this.statisticsConverter = statisticsConverter;
+  }
 
   @GetMapping
   @ApiOperation(value = "Get executor group statistics", response = StatisticsResponse.class, notes = "Returns counts of queued and executing workflow instances.")
   public Mono<ResponseEntity<?>> queryStatistics() {
-    return handleExceptions(
-        () -> scheduler.wrapBlocking(() -> ok(statisticsConverter.convert(statisticsService.getStatistics()))));
+    return handleExceptions(() -> wrapBlocking(() -> ok(statisticsConverter.convert(statisticsService.getStatistics()))));
   }
 
   @GetMapping(path = "/workflow/{type}")
@@ -55,7 +57,7 @@ public class StatisticsResource extends SpringWebResource {
       @RequestParam(value = "createdBefore", required = false) @ApiParam("Include only workflow instances created before given time") DateTime createdBefore,
       @RequestParam(value = "modifiedAfter", required = false) @ApiParam("Include only workflow instances modified after given time") DateTime modifiedAfter,
       @RequestParam(value = "modifiedBefore", required = false) @ApiParam("Include only workflow instances modified before given time") DateTime modifiedBefore) {
-    return handleExceptions(() -> scheduler.wrapBlocking(() -> ok(statisticsConverter.convert(
+    return handleExceptions(() -> wrapBlocking(() -> ok(statisticsConverter.convert(
         statisticsService.getWorkflowDefinitionStatistics(type, createdAfter, createdBefore, modifiedAfter, modifiedBefore)))));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/StatisticsResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/StatisticsResource.java
@@ -43,7 +43,8 @@ public class StatisticsResource extends SpringWebResource {
   @GetMapping
   @ApiOperation(value = "Get executor group statistics", response = StatisticsResponse.class, notes = "Returns counts of queued and executing workflow instances.")
   public Mono<ResponseEntity<?>> queryStatistics() {
-    return handleExceptions(() -> scheduler.wrapBlocking(() -> ok(statisticsConverter.convert(statisticsService.getStatistics()))));
+    return handleExceptions(
+        () -> scheduler.wrapBlocking(() -> ok(statisticsConverter.convert(statisticsService.getStatistics()))));
   }
 
   @GetMapping(path = "/workflow/{type}")

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowDefinitionResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowDefinitionResource.java
@@ -17,11 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.nflow.engine.internal.dao.WorkflowDefinitionDao;
 import io.nflow.engine.service.WorkflowDefinitionService;
+import io.nflow.rest.config.springweb.SchedulerService;
 import io.nflow.rest.v1.converter.ListWorkflowDefinitionConverter;
 import io.nflow.rest.v1.msg.ListWorkflowDefinitionResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping(value = NFLOW_SPRING_WEB_PATH_PREFIX + NFLOW_WORKFLOW_DEFINITION_PATH, produces = APPLICATION_JSON_VALUE)
@@ -32,20 +35,22 @@ public class WorkflowDefinitionResource extends SpringWebResource {
   private final WorkflowDefinitionService workflowDefinitions;
   private final ListWorkflowDefinitionConverter converter;
   private final WorkflowDefinitionDao workflowDefinitionDao;
+  private final SchedulerService scheduler;
 
   @Autowired
   public WorkflowDefinitionResource(WorkflowDefinitionService workflowDefinitions, ListWorkflowDefinitionConverter converter,
-      WorkflowDefinitionDao workflowDefinitionDao) {
+      WorkflowDefinitionDao workflowDefinitionDao, SchedulerService scheduler) {
     this.workflowDefinitions = workflowDefinitions;
     this.converter = converter;
     this.workflowDefinitionDao = workflowDefinitionDao;
+    this.scheduler = scheduler;
   }
 
   @GetMapping
   @ApiOperation(value = "List workflow definitions", response = ListWorkflowDefinitionResponse.class, responseContainer = "List", notes = "Returns workflow definition(s): all possible states, transitions between states and other setting metadata. The workflow definition can deployed in nFlow engine or historical workflow definition stored in the database.")
-  public ResponseEntity<?> listWorkflowDefinitions(
+  public Mono<ResponseEntity<?>> listWorkflowDefinitions(
       @RequestParam(value = "type", defaultValue = "") @ApiParam("Included workflow types") List<String> types) {
     return handleExceptions(
-        () -> ok(super.listWorkflowDefinitions(types, workflowDefinitions, converter, workflowDefinitionDao)));
+        () -> scheduler.wrapBlocking(() -> ok(super.listWorkflowDefinitions(types, workflowDefinitions, converter, workflowDefinitionDao))));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowDefinitionResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowDefinitionResource.java
@@ -50,7 +50,7 @@ public class WorkflowDefinitionResource extends SpringWebResource {
   @ApiOperation(value = "List workflow definitions", response = ListWorkflowDefinitionResponse.class, responseContainer = "List", notes = "Returns workflow definition(s): all possible states, transitions between states and other setting metadata. The workflow definition can deployed in nFlow engine or historical workflow definition stored in the database.")
   public Mono<ResponseEntity<?>> listWorkflowDefinitions(
       @RequestParam(value = "type", defaultValue = "") @ApiParam("Included workflow types") List<String> types) {
-    return handleExceptions(
-        () -> scheduler.wrapBlocking(() -> ok(super.listWorkflowDefinitions(types, workflowDefinitions, converter, workflowDefinitionDao))));
+    return handleExceptions(() -> scheduler
+        .wrapBlocking(() -> ok(super.listWorkflowDefinitions(types, workflowDefinitions, converter, workflowDefinitionDao))));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowDefinitionResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowDefinitionResource.java
@@ -7,7 +7,8 @@ import static org.springframework.http.ResponseEntity.ok;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import javax.inject.Inject;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +24,6 @@ import io.nflow.rest.v1.msg.ListWorkflowDefinitionResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -35,22 +35,21 @@ public class WorkflowDefinitionResource extends SpringWebResource {
   private final WorkflowDefinitionService workflowDefinitions;
   private final ListWorkflowDefinitionConverter converter;
   private final WorkflowDefinitionDao workflowDefinitionDao;
-  private final SchedulerService scheduler;
 
-  @Autowired
-  public WorkflowDefinitionResource(WorkflowDefinitionService workflowDefinitions, ListWorkflowDefinitionConverter converter,
-      WorkflowDefinitionDao workflowDefinitionDao, SchedulerService scheduler) {
+  @Inject
+  public WorkflowDefinitionResource(SchedulerService scheduler, WorkflowDefinitionService workflowDefinitions,
+      ListWorkflowDefinitionConverter converter, WorkflowDefinitionDao workflowDefinitionDao) {
+    super(scheduler);
     this.workflowDefinitions = workflowDefinitions;
     this.converter = converter;
     this.workflowDefinitionDao = workflowDefinitionDao;
-    this.scheduler = scheduler;
   }
 
   @GetMapping
   @ApiOperation(value = "List workflow definitions", response = ListWorkflowDefinitionResponse.class, responseContainer = "List", notes = "Returns workflow definition(s): all possible states, transitions between states and other setting metadata. The workflow definition can deployed in nFlow engine or historical workflow definition stored in the database.")
   public Mono<ResponseEntity<?>> listWorkflowDefinitions(
       @RequestParam(value = "type", defaultValue = "") @ApiParam("Included workflow types") List<String> types) {
-    return handleExceptions(() -> scheduler
-        .wrapBlocking(() -> ok(super.listWorkflowDefinitions(types, workflowDefinitions, converter, workflowDefinitionDao))));
+    return handleExceptions(() -> wrapBlocking(
+        () -> ok(super.listWorkflowDefinitions(types, workflowDefinitions, converter, workflowDefinitionDao))));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowExecutorResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowExecutorResource.java
@@ -6,7 +6,8 @@ import static java.util.stream.Collectors.toList;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.ResponseEntity.ok;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import javax.inject.Inject;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +20,6 @@ import io.nflow.rest.v1.converter.ListWorkflowExecutorConverter;
 import io.nflow.rest.v1.msg.ListWorkflowExecutorResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -30,20 +30,19 @@ public class WorkflowExecutorResource extends SpringWebResource {
 
   private final WorkflowExecutorService workflowExecutors;
   private final ListWorkflowExecutorConverter converter;
-  private final SchedulerService scheduler;
 
-  @Autowired
-  public WorkflowExecutorResource(WorkflowExecutorService workflowExecutors, ListWorkflowExecutorConverter converter,
-      SchedulerService scheduler) {
+  @Inject
+  public WorkflowExecutorResource(SchedulerService scheduler, WorkflowExecutorService workflowExecutors,
+      ListWorkflowExecutorConverter converter) {
+    super(scheduler);
     this.workflowExecutors = workflowExecutors;
     this.converter = converter;
-    this.scheduler = scheduler;
   }
 
   @GetMapping
   @ApiOperation(value = "List workflow executors", response = ListWorkflowExecutorResponse.class, responseContainer = "List")
   public Mono<ResponseEntity<?>> listWorkflowExecutors() {
-    return handleExceptions(() -> scheduler
-        .wrapBlocking(() -> ok(workflowExecutors.getWorkflowExecutors().stream().map(converter::convert).collect(toList()))));
+    return handleExceptions(() -> wrapBlocking(
+        () -> ok(workflowExecutors.getWorkflowExecutors().stream().map(converter::convert).collect(toList()))));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowExecutorResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowExecutorResource.java
@@ -43,7 +43,7 @@ public class WorkflowExecutorResource extends SpringWebResource {
   @GetMapping
   @ApiOperation(value = "List workflow executors", response = ListWorkflowExecutorResponse.class, responseContainer = "List")
   public Mono<ResponseEntity<?>> listWorkflowExecutors() {
-    return handleExceptions(
-        () -> scheduler.wrapBlocking(() -> ok(workflowExecutors.getWorkflowExecutors().stream().map(converter::convert).collect(toList()))));
+    return handleExceptions(() -> scheduler
+        .wrapBlocking(() -> ok(workflowExecutors.getWorkflowExecutors().stream().map(converter::convert).collect(toList()))));
   }
 }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
@@ -70,8 +70,7 @@ public class WorkflowInstanceResource extends SpringWebResource {
   @Inject
   public WorkflowInstanceResource(WorkflowInstanceService workflowInstances, CreateWorkflowConverter createWorkflowConverter,
       ListWorkflowInstanceConverter listWorkflowConverter, WorkflowInstanceFactory workflowInstanceFactory,
-      WorkflowInstanceDao workflowInstanceDao,
-      SchedulerService scheduler) {
+      WorkflowInstanceDao workflowInstanceDao, SchedulerService scheduler) {
     this.workflowInstances = workflowInstances;
     this.createWorkflowConverter = createWorkflowConverter;
     this.listWorkflowConverter = listWorkflowConverter;
@@ -102,7 +101,8 @@ public class WorkflowInstanceResource extends SpringWebResource {
   @ApiResponses({ @ApiResponse(code = 204, message = "If update was successful"),
       @ApiResponse(code = 400, message = "If instance could not be updated, for example when state variable value was too long"),
       @ApiResponse(code = 409, message = "If workflow was executing and no update was done") })
-  public Mono<ResponseEntity<?>> updateWorkflowInstance(@ApiParam("Internal id for workflow instance") @PathVariable("id") long id,
+  public Mono<ResponseEntity<?>> updateWorkflowInstance(
+      @ApiParam("Internal id for workflow instance") @PathVariable("id") long id,
       @RequestBody @ApiParam("Submitted workflow instance information") UpdateWorkflowInstanceRequest req) {
     return handleExceptions(() -> {
       return scheduler.wrapBlocking(() -> {
@@ -120,10 +120,9 @@ public class WorkflowInstanceResource extends SpringWebResource {
   public Mono<ResponseEntity<?>> fetchWorkflowInstance(@ApiParam("Internal id for workflow instance") @PathVariable("id") long id,
       @RequestParam(value = "include", required = false) @ApiParam(value = INCLUDE_PARAM_DESC, allowableValues = INCLUDE_PARAM_VALUES, allowMultiple = true) String include,
       @RequestParam(value = "maxActions", required = false) @ApiParam("Maximum number of actions returned for each workflow instance") Long maxActions) {
-    return handleExceptions(
-        () -> scheduler.wrapBlocking(() -> {
-           return ok(super.fetchWorkflowInstance(id, include, maxActions, this.workflowInstances, this.listWorkflowConverter));
-        }));
+    return handleExceptions(() -> scheduler.wrapBlocking(() -> {
+      return ok(super.fetchWorkflowInstance(id, include, maxActions, this.workflowInstances, this.listWorkflowConverter));
+    }));
   }
 
   @GetMapping
@@ -140,8 +139,8 @@ public class WorkflowInstanceResource extends SpringWebResource {
       @RequestParam(value = "include", required = false) @ApiParam(value = INCLUDE_PARAM_DESC, allowableValues = INCLUDE_PARAM_VALUES, allowMultiple = true) String include,
       @RequestParam(value = "maxResults", required = false) @ApiParam("Maximum number of workflow instances to be returned") Long maxResults,
       @RequestParam(value = "maxActions", required = false) @ApiParam("Maximum number of actions returned for each workflow instance") Long maxActions) {
-    return handleExceptions(
-        () -> scheduler.wrapBlocking(() -> ok(super.listWorkflowInstances(ids, types, parentWorkflowId, parentActionId, states, statuses, businessKey,
+    return handleExceptions(() -> scheduler.wrapBlocking(
+        () -> ok(super.listWorkflowInstances(ids, types, parentWorkflowId, parentActionId, states, statuses, businessKey,
             externalId, include, maxResults, maxActions, this.workflowInstances, this.listWorkflowConverter).iterator())));
   }
 
@@ -150,7 +149,7 @@ public class WorkflowInstanceResource extends SpringWebResource {
   public Mono<ResponseEntity<?>> setSignal(@ApiParam("Internal id for workflow instance") @PathVariable("id") long id,
       @RequestBody @Valid @ApiParam("New signal value") SetSignalRequest req) {
     return handleExceptions(() -> {
-      return scheduler.wrapBlocking(() ->  {
+      return scheduler.wrapBlocking(() -> {
         SetSignalResponse response = new SetSignalResponse();
         response.setSignalSuccess = workflowInstances.setSignal(id, ofNullable(req.signal), req.reason,
             WorkflowActionType.externalChange);
@@ -164,7 +163,7 @@ public class WorkflowInstanceResource extends SpringWebResource {
   public Mono<ResponseEntity<?>> wakeup(@ApiParam("Internal id for workflow instance") @PathVariable("id") long id,
       @RequestBody @Valid @ApiParam("Expected states") WakeupRequest req) {
     return handleExceptions(() -> {
-      return scheduler.wrapBlocking(() ->  {
+      return scheduler.wrapBlocking(() -> {
         WakeupResponse response = new WakeupResponse();
         List<String> expectedStates = ofNullable(req.expectedStates).orElseGet(Collections::emptyList);
         response.wakeupSuccess = workflowInstances.wakeupWorkflowInstance(id, expectedStates);

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
@@ -59,6 +59,7 @@ import reactor.core.publisher.Mono;
 @Api("nFlow workflow instance management")
 @Component
 public class WorkflowInstanceResource extends SpringWebResource {
+
   private final WorkflowInstanceService workflowInstances;
   private final CreateWorkflowConverter createWorkflowConverter;
   private final ListWorkflowInstanceConverter listWorkflowConverter;

--- a/nflow-rest-api-spring-web/src/test/java/io/nflow/rest/v1/springweb/SpringWebResourceTest.java
+++ b/nflow-rest-api-spring-web/src/test/java/io/nflow/rest/v1/springweb/SpringWebResourceTest.java
@@ -11,13 +11,15 @@ import org.springframework.http.ResponseEntity;
 
 import io.nflow.rest.v1.msg.ErrorResponse;
 
+import reactor.core.publisher.Mono;
+
 public class SpringWebResourceTest {
 
   private final SpringWebResource resource = new TestResource();
 
   @Test
   public void handleExceptionsReturnsResponseWhenSuccessful() {
-    ResponseEntity<?> response = resource.handleExceptions(() -> ok("ok"));
+    ResponseEntity<?> response = resource.handleExceptions(() -> Mono.just(ok("ok"))).block();
 
     assertThat(response.getStatusCode(), is(OK));
     assertThat(response.getBody(), is("ok"));
@@ -27,7 +29,7 @@ public class SpringWebResourceTest {
   public void handleExceptionsReturnsResponseOnFailure() {
     ResponseEntity<?> response = resource.handleExceptions(() -> {
       throw new RuntimeException("error");
-    });
+    }).block();
 
     assertThat(response.getStatusCode(), is(INTERNAL_SERVER_ERROR));
     assertThat(((ErrorResponse) response.getBody()).error, is("error"));

--- a/nflow-rest-api-spring-web/src/test/java/io/nflow/rest/v1/springweb/SpringWebResourceTest.java
+++ b/nflow-rest-api-spring-web/src/test/java/io/nflow/rest/v1/springweb/SpringWebResourceTest.java
@@ -5,13 +5,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.ResponseEntity.ok;
+import static reactor.core.publisher.Mono.just;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 
 import io.nflow.rest.v1.msg.ErrorResponse;
-
-import reactor.core.publisher.Mono;
 
 public class SpringWebResourceTest {
 
@@ -19,7 +18,7 @@ public class SpringWebResourceTest {
 
   @Test
   public void handleExceptionsReturnsResponseWhenSuccessful() {
-    ResponseEntity<?> response = resource.handleExceptions(() -> Mono.just(ok("ok"))).block();
+    ResponseEntity<?> response = resource.handleExceptions(() -> just(ok("ok"))).block();
 
     assertThat(response.getStatusCode(), is(OK));
     assertThat(response.getBody(), is("ok"));

--- a/nflow-rest-api-spring-web/src/test/java/io/nflow/rest/v1/springweb/SpringWebResourceTest.java
+++ b/nflow-rest-api-spring-web/src/test/java/io/nflow/rest/v1/springweb/SpringWebResourceTest.java
@@ -35,6 +35,9 @@ public class SpringWebResourceTest {
   }
 
   class TestResource extends SpringWebResource {
-    // test resource
+
+    protected TestResource() {
+      super(null);
+    }
   }
 }


### PR DESCRIPTION
Currently when using nflow-netty, the netty EventLoop thread blocks during synchronous JDBC database access. Fix this by introducing a separate thread pool for REST API calls.