### PR TITLE
Fix webflux error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 **Details**
 - `nflow-engine`
   - Add `disabled` state (type `manual`) to `CronWorkflow` to support disabling the work. By default there is no state method for the `disabled` state, but it can added in your workflow definition that extends `CronWorkflow` to execute custom logic when the workflow enters the `disabled` state.
+- `nflow-rest-api-common` and `nflow-rest-api-spring-web`
+  - Fix exception to HTTP status conversion issue when using Netty
 
 ## 7.2.3 (2021-02-22)
 

--- a/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
+++ b/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
@@ -1,9 +1,12 @@
 package io.nflow.netty;
 
 import static io.nflow.rest.v1.ResourcePaths.NFLOW_WORKFLOW_DEFINITION_PATH;
+import static io.nflow.rest.v1.ResourcePaths.NFLOW_WORKFLOW_INSTANCE_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.HashMap;
@@ -52,6 +55,7 @@ public class StartNflowTest {
     assertEquals("true", ctx.getEnvironment().getProperty("nflow.autoinit"));
 
     smokeTestRestApi(restApiPrefix);
+    smokeTestRestApiErrorHandling(restApiPrefix);
   }
 
   private void smokeTestRestApi(String restApiPrefix) {
@@ -61,5 +65,18 @@ public class StartNflowTest {
     JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
     assertTrue(responseBody.isArray());
   }
+
+  /*
+    Smoke test for io.nflow.rest.v1.springweb.SpringWebResource#handleExceptions
+   */
+  private void smokeTestRestApiErrorHandling(String restApiPrefix) {
+      WebClient client = WebClient.builder().baseUrl("http://localhost:7500").build();
+      ClientResponse response = client.get().uri(restApiPrefix + NFLOW_WORKFLOW_INSTANCE_PATH + "/id/0213132").exchange().block();
+      assertEquals(NOT_FOUND, response.statusCode());
+      JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
+      assertNotNull(responseBody);
+      assertFalse(responseBody.isEmpty());
+  }
+
 
 }

--- a/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
+++ b/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
@@ -23,8 +23,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class StartNflowTest {
 
+  private static final String DEFAULT_LOCALHOST_SERVER_PORT = "7500";
+  private static final String DEFAULT_LOCALHOST_SERVER_ADDRESS = "http://localhost:" + DEFAULT_LOCALHOST_SERVER_PORT;
+
   public class TestApplicationListener implements ApplicationListener<ApplicationContextEvent> {
     public ApplicationContextEvent applicationContextEvent;
+
     @Override
     public void onApplicationEvent(ApplicationContextEvent event) {
       applicationContextEvent = event;
@@ -47,7 +51,7 @@ public class StartNflowTest {
     ApplicationContext ctx = startNflow.startNetty(7500, "local", "", properties);
 
     assertNotNull(testListener.applicationContextEvent);
-    assertEquals("7500", ctx.getEnvironment().getProperty("port"));
+    assertEquals(DEFAULT_LOCALHOST_SERVER_PORT, ctx.getEnvironment().getProperty("port"));
     assertEquals("local", ctx.getEnvironment().getProperty("env"));
     assertEquals("externallyDefinedExecutorGroup", ctx.getEnvironment().getProperty("nflow.executor.group"));
     assertEquals("true", ctx.getEnvironment().getProperty("nflow.db.create_on_startup"));
@@ -59,8 +63,7 @@ public class StartNflowTest {
   }
 
   private void smokeTestRestApi(String restApiPrefix) {
-    WebClient client = WebClient.builder().baseUrl("http://localhost:7500").build();
-    ClientResponse response = client.get().uri(restApiPrefix + NFLOW_WORKFLOW_DEFINITION_PATH).exchange().block();
+    ClientResponse response = getFromDefaultServer(restApiPrefix + NFLOW_WORKFLOW_DEFINITION_PATH);
     assertEquals(OK, response.statusCode());
     JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
     assertTrue(responseBody.isArray());
@@ -70,12 +73,16 @@ public class StartNflowTest {
     Smoke test for io.nflow.rest.v1.springweb.SpringWebResource#handleExceptions
    */
   private void smokeTestRestApiErrorHandling(String restApiPrefix) {
-      WebClient client = WebClient.builder().baseUrl("http://localhost:7500").build();
-      ClientResponse response = client.get().uri(restApiPrefix + NFLOW_WORKFLOW_INSTANCE_PATH + "/id/0213132").exchange().block();
-      assertEquals(NOT_FOUND, response.statusCode());
-      JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
-      assertNotNull(responseBody);
-      assertFalse(responseBody.isEmpty());
+    ClientResponse response = getFromDefaultServer(restApiPrefix + NFLOW_WORKFLOW_INSTANCE_PATH + "/id/0213132");
+    assertEquals(NOT_FOUND, response.statusCode());
+    JsonNode responseBody = response.bodyToMono(JsonNode.class).block();
+    assertNotNull(responseBody);
+    assertFalse(responseBody.isEmpty());
+  }
+
+  private ClientResponse getFromDefaultServer(String url) {
+    WebClient client = WebClient.builder().baseUrl(DEFAULT_LOCALHOST_SERVER_ADDRESS).build();
+    return client.get().uri(url).exchange().block();
   }
 
 

--- a/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
+++ b/nflow-netty/src/test/java/io/nflow/netty/StartNflowTest.java
@@ -69,9 +69,7 @@ public class StartNflowTest {
     assertTrue(responseBody.isArray());
   }
 
-  /*
-    Smoke test for io.nflow.rest.v1.springweb.SpringWebResource#handleExceptions
-   */
+  // Smoke test for io.nflow.rest.v1.springweb.SpringWebResource#handleExceptions
   private void smokeTestRestApiErrorHandling(String restApiPrefix) {
     ClientResponse response = getFromDefaultServer(restApiPrefix + NFLOW_WORKFLOW_INSTANCE_PATH + "/id/0213132");
     assertEquals(NOT_FOUND, response.statusCode());
@@ -84,6 +82,4 @@ public class StartNflowTest {
     WebClient client = WebClient.builder().baseUrl(DEFAULT_LOCALHOST_SERVER_ADDRESS).build();
     return client.get().uri(url).exchange().block();
   }
-
-
 }

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
@@ -1,6 +1,9 @@
 package io.nflow.rest.v1;
 
 import static io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.util.Collections.sort;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.stream.Collectors.toCollection;
@@ -185,11 +188,11 @@ public abstract class ResourceBase {
 
   protected int resolveExceptionHttpStatus(Throwable t) {
     if (t instanceof IllegalArgumentException) {
-      return 400;
+      return HTTP_BAD_REQUEST;
     } else if (t instanceof NflowNotFoundException) {
-      return 404;
+      return HTTP_NOT_FOUND;
     }
-    return 500;
+    return HTTP_INTERNAL_ERROR;
   }
 
   protected <T> T handleExceptions(Supplier<T> response, BiFunction<Integer, ErrorResponse, T> error) {

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
@@ -186,7 +186,7 @@ public abstract class ResourceBase {
   protected int resolveExceptionHttpStatus(Throwable t) {
     if (t instanceof IllegalArgumentException) {
       return 400;
-    } else if(t instanceof NflowNotFoundException) {
+    } else if (t instanceof NflowNotFoundException) {
       return 404;
     }
 

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
@@ -183,15 +183,22 @@ public abstract class ResourceBase {
     return listWorkflowConverter.convert(instance, includes);
   }
 
+  protected int resolveExceptionHttpStatus(Throwable t) {
+    if (t instanceof IllegalArgumentException) {
+      return 400;
+    } else if(t instanceof NflowNotFoundException) {
+      return 404;
+    }
+
+    return 500;
+  }
+
   protected <T> T handleExceptions(Supplier<T> response, BiFunction<Integer, ErrorResponse, T> error) {
     try {
       return response.get();
-    } catch (IllegalArgumentException e) {
-      return error.apply(400, new ErrorResponse(e.getMessage()));
-    } catch (NflowNotFoundException e) {
-      return error.apply(404, new ErrorResponse(e.getMessage()));
     } catch (Throwable t) {
-      return error.apply(500, new ErrorResponse(t.getMessage()));
+      int code = resolveExceptionHttpStatus(t);
+      return error.apply(code, new ErrorResponse(t.getMessage()));
     }
   }
 }

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
@@ -189,7 +189,6 @@ public abstract class ResourceBase {
     } else if (t instanceof NflowNotFoundException) {
       return 404;
     }
-
     return 500;
   }
 

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
@@ -1,16 +1,17 @@
 package io.nflow.rest.v1.springweb;
 
-import io.nflow.rest.config.springweb.SchedulerService;
-import io.nflow.rest.v1.ResourceBase;
-import io.nflow.rest.v1.msg.ErrorResponse;
-import org.springframework.http.ResponseEntity;
-import reactor.core.publisher.Mono;
+import static org.springframework.http.ResponseEntity.status;
+import static reactor.core.publisher.Mono.just;
 
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
-import static org.springframework.http.ResponseEntity.status;
-import static reactor.core.publisher.Mono.just;
+import org.springframework.http.ResponseEntity;
+
+import io.nflow.rest.config.springweb.SchedulerService;
+import io.nflow.rest.v1.ResourceBase;
+import io.nflow.rest.v1.msg.ErrorResponse;
+import reactor.core.publisher.Mono;
 
 public abstract class SpringWebResource extends ResourceBase {
 

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/SpringWebResource.java
@@ -1,17 +1,16 @@
 package io.nflow.rest.v1.springweb;
 
-import static org.springframework.http.ResponseEntity.status;
-import static reactor.core.publisher.Mono.just;
+import io.nflow.rest.config.springweb.SchedulerService;
+import io.nflow.rest.v1.ResourceBase;
+import io.nflow.rest.v1.msg.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
-import org.springframework.http.ResponseEntity;
-
-import io.nflow.rest.config.springweb.SchedulerService;
-import io.nflow.rest.v1.ResourceBase;
-import io.nflow.rest.v1.msg.ErrorResponse;
-import reactor.core.publisher.Mono;
+import static org.springframework.http.ResponseEntity.status;
+import static reactor.core.publisher.Mono.just;
 
 public abstract class SpringWebResource extends ResourceBase {
 
@@ -26,7 +25,9 @@ public abstract class SpringWebResource extends ResourceBase {
   }
 
   protected Mono<ResponseEntity<?>> handleExceptions(Supplier<Mono<ResponseEntity<?>>> response) {
-    return handleExceptions(response::get, this::toErrorResponse);
+    return Mono.just(response)
+        .flatMap(Supplier::get)
+        .onErrorResume(ex -> toErrorResponse(resolveExceptionHttpStatus(ex), new ErrorResponse(ex.getMessage())));
   }
 
   private Mono<ResponseEntity<?>> toErrorResponse(int statusCode, ErrorResponse body) {


### PR DESCRIPTION
Currently (at least) `NflowNotFoundException`s seem to get mapped to 500 instead of 404. 