### PR TITLE
Persist workflow instance query parameters to URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Highlights**
 - `nflow-explorer`
   - Sortable workflow definitions and instance search result table
+  - Persist workflow instance query parameters to URL
 
 **Details**
 - `nflow-explorer`

--- a/nflow-explorer/src/app/config/routes.js
+++ b/nflow-explorer/src/app/config/routes.js
@@ -38,7 +38,7 @@
       })
       .state('search', {
         parent: 'searchTab',
-        url: '/search?type&state&parentWorkflowId',
+        url: '/search?type&state&status&businessKey&externalId&id&parentWorkflowId',
         templateUrl: 'app/search/search.html',
         controller: 'SearchCtrl as ctrl',
         resolve: {

--- a/nflow-explorer/src/app/search/criteriaModel.js
+++ b/nflow-explorer/src/app/search/criteriaModel.js
@@ -18,7 +18,12 @@
 
       self.model.definition = ensureTypeInDefinitions(initValues.type, definitions);
       self.model.state = ensureStateIdInDefinitionStates(initValues.stateId, self.model.definition);
+      self.model.status = nonValueToNull(initValues.status);
+      self.model.businessKey = nonValueToNull(initValues.businessKey);
+      self.model.externalId = nonValueToNull(initValues.externalId);
+      self.model.id = nonValueToNull(initValues.id);
       self.model.parentWorkflowId = nonValueToNull(initValues.parentWorkflowId);
+      self.allDefinitions = initValues.type === 'all';
     }
 
     function toQuery() {
@@ -31,7 +36,7 @@
     }
 
     function isEmpty() {
-      return _.isEmpty(omitNonValues(self.model));
+      return _.isEmpty(omitNonValues(self.model)) && !self.allDefinitions;
     }
 
     function onDefinitionChange() {

--- a/nflow-explorer/src/app/search/search.js
+++ b/nflow-explorer/src/app/search/search.js
@@ -16,6 +16,10 @@
     CriteriaModel.initialize({
         type: $stateParams.type,
         stateId: $stateParams.state,
+        status: $stateParams.status,
+        businessKey: $stateParams.businessKey,
+        externalId: $stateParams.externalId,
+        id: toInt($stateParams.id),
         parentWorkflowId: toInt($stateParams.parentWorkflowId)
       },
       definitions);

--- a/nflow-explorer/src/app/search/searchForm.js
+++ b/nflow-explorer/src/app/search/searchForm.js
@@ -22,23 +22,38 @@
     };
   });
 
-  m.controller('SearchFormCtrl', function($timeout, CriteriaModel, WorkflowService, WorkflowInstanceStatus) {
+  m.controller('SearchFormCtrl', function($state, $timeout, CriteriaModel, WorkflowService, WorkflowInstanceStatus) {
     var self = this;
     self.showIndicator = false;
     self.instanceStatuses = _.values(WorkflowInstanceStatus);
     self.model = CriteriaModel.model;
-    self.search = search;
+    self.search = navigateSearch;
+    self.executeSearch = executeSearch;
     self.onTypeChange = CriteriaModel.onDefinitionChange;
 
     initialize();
 
     function initialize() {
       if (!CriteriaModel.isEmpty()) {
-        search();
+        executeSearch();
       }
     }
 
-    function search() {
+    function navigateSearch() {
+      $state.go('search', {
+        type: (self.model.definition && self.model.definition.type) || 'all',
+        state: self.model.state && self.model.state.id,
+        status: self.model.status,
+        businessKey: self.model.businessKey,
+        externalId: self.model.externalId,
+        id: self.model.id,
+        parentWorkflowId: self.model.parentWorkflowId,
+      }, {
+        reload: true
+      });
+    }
+
+    function executeSearch() {
       var t = $timeout(function() { self.showIndicator = true; }, 500);
 
       WorkflowService.query(CriteriaModel.toQuery())

--- a/nflow-explorer/test/spec/search/criteriaModel.js
+++ b/nflow-explorer/test/spec/search/criteriaModel.js
@@ -19,38 +19,44 @@ describe('Service: CriteriaModel', function () {
   describe('initialize', function () {
     it('sets fields with empty input', function () {
       CriteriaModel.initialize({}, definitions);
-      expect(actualModel).toEqual({ definition: null, state: null,
-                                    parentWorkflowId: null });
+      expect(actualModel).toEqual({ definition: null, state: null, parentWorkflowId: null,
+                                    status: null, businessKey: null, externalId: null, id: null });
     });
 
     it('sets definition matching to type', function () {
       CriteriaModel.initialize({ type: 'foo'}, definitions);
-      expect(actualModel).toEqual({ definition: definitions[0], state: null, parentWorkflowId: null });
+      expect(actualModel).toEqual({ definition: definitions[0], state: null, parentWorkflowId: null,
+                                    status: null, businessKey: null, externalId: null, id: null });
     });
 
     it('sets unknown definition as null', function () {
       CriteriaModel.initialize({ type: 'not in definitions'}, definitions);
-      expect(actualModel).toEqual({ definition: null, state: null, parentWorkflowId: null });
+      expect(actualModel).toEqual({ definition: null, state: null, parentWorkflowId: null,
+                                    status: null, businessKey: null, externalId: null, id: null });
     });
 
     it('sets known definition state', function () {
       CriteriaModel.initialize({ type: 'foo', stateId: 'bar'}, definitions);
-      expect(actualModel).toEqual({ definition: definitions[0], state: definitions[0].states[0], parentWorkflowId: null });
+      expect(actualModel).toEqual({ definition: definitions[0], state: definitions[0].states[0], parentWorkflowId: null,
+                                    status: null, businessKey: null, externalId: null, id: null });
     });
 
     it('sets unknown state to null', function () {
       CriteriaModel.initialize({ type: 'foo', stateId: 'not in foo states'}, definitions);
-      expect(actualModel).toEqual({ definition: definitions[0], state: null, parentWorkflowId: null });
+      expect(actualModel).toEqual({ definition: definitions[0], parentWorkflowId: null, state: null,
+                                    status: null, businessKey: null, externalId: null, id: null });
     });
 
     it('sets parentWorkflowId to parsed integer', function () {
       CriteriaModel.initialize({parentWorkflowId: '123'}, definitions);
-      expect(actualModel).toEqual({ definition: null, state: null, parentWorkflowId: '123' });
+      expect(actualModel).toEqual({ definition: null, state: null, parentWorkflowId: '123',
+                                    status: null, businessKey: null, externalId: null, id: null });
     });
 
     it('input properties other than type, state and parentWorkflowId are ignored', function () {
       CriteriaModel.initialize({ foo: 'bar'}, definitions);
-      expect(actualModel).toEqual({ definition: null, state: null, parentWorkflowId: null });
+      expect(actualModel).toEqual({ definition: null, state: null, parentWorkflowId: null,
+                                    status: null, businessKey: null, externalId: null, id: null });
     });
   });
 

--- a/nflow-explorer/test/spec/search/search.js
+++ b/nflow-explorer/test/spec/search/search.js
@@ -13,7 +13,8 @@ describe('Controller: SearchCtrl', function () {
 
   function getCtrl(CriteriaModel) {
     return $controller('SearchCtrl', {
-      $stateParams: {type: 'expected type', state: 'expected state id',
+      $stateParams: {type: 'expected type', state: 'expected state id', status: 'inProgress',
+                      businessKey: 'foobar', externalId: 'barfoo', id: 321,
                       parentWorkflowId: '123'},
       definitions: ['expected definition'],
       CriteriaModel: CriteriaModel
@@ -33,7 +34,8 @@ describe('Controller: SearchCtrl', function () {
   it('initializes criteria model from route params', function () {
     var mock = sinon.mock(CriteriaModel);
     var expectation = mock.expects('initialize').withExactArgs(
-      {type: 'expected type', stateId: 'expected state id', parentWorkflowId: 123},
+      {type: 'expected type', stateId: 'expected state id', status: 'inProgress',
+        businessKey: 'foobar', externalId: 'barfoo', id: 321, parentWorkflowId: 123},
       ['expected definition']
     );
 

--- a/nflow-explorer/test/spec/search/searchForm.js
+++ b/nflow-explorer/test/spec/search/searchForm.js
@@ -99,7 +99,7 @@ describe('Directive: searchForm', function () {
         $httpBackend.flush();
         expect(ctrl.showIndicator).toBeFalsy();
 
-        ctrl.search();
+        ctrl.executeSearch();
         $timeout.flush(499);
         expect(ctrl.showIndicator).toBeFalsy();
         $timeout.flush(1);


### PR DESCRIPTION
Set the workflow instance query parameters to state, when search button is pressed. This again sets the parameters to URL, and reloads the search controller with the new query parameters, that are automatically used for making the actual query. When navigating away from the search page, browser back-button will work and the previous query result will be again rendered.

There's a corner case when first opening search page vs. searching without any criteria. The latter is handled by fake workflow definition type "all", which is ignored as a query parameter, but whose presence forces the search page to make the REST call.