### PR TITLE
Use workflowId to query the results in nflow_workflow_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## 7.3.1-SNAPSHOT (future release)
 
 **Highlights**
+- `nflow-engine`
+  - Optimize fetching workflow with large action history with many modified state variables.
 
 **Details**
 - `nflow-jetty`
   - Explicitly depend on jackson-databind so that projects including the nflow-jetty do not have to specify the version explicitly
   - Dependency updates:
     - jetty 9.4.41.v20210516
+- `nflow-engine`
+  - Improve SQL performance by using workflowId in the query which fetches the state of actions from `nflow_workflow_state`
 
 ## 7.3.0 (2021-04-05)
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -739,10 +739,10 @@ public class WorkflowInstanceDao {
     } else {
       sql = "select nflow_workflow_state.* from ("
           + sqlVariants.limit("select id from nflow_workflow_action where workflow_id = ? order by id desc", maxActions)
-          + ") action_id inner join nflow_workflow_state on action_id.id = nflow_workflow_state.action_id "
+          + ") action_id inner join nflow_workflow_state on nflow_workflow_state.workflow_id = ? and action_id.id = nflow_workflow_state.action_id "
           + "order by nflow_workflow_state.action_id, nflow_workflow_state.state_key asc";
     }
-    return jdbc.query(sql, new WorkflowActionStateRowMapper(), instance.id);
+    return jdbc.query(sql, new WorkflowActionStateRowMapper(), instance.id, instance.id);
   }
 
   @Transactional(propagation = MANDATORY)

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -736,13 +736,14 @@ public class WorkflowInstanceDao {
     String sql;
     if (actions < maxActions) {
       sql = "select * from nflow_workflow_state where workflow_id = ? order by action_id, state_key asc";
+      return jdbc.query(sql, new WorkflowActionStateRowMapper(), instance.id);
     } else {
       sql = "select nflow_workflow_state.* from ("
           + sqlVariants.limit("select id from nflow_workflow_action where workflow_id = ? order by id desc", maxActions)
           + ") action_id inner join nflow_workflow_state on nflow_workflow_state.workflow_id = ? and action_id.id = nflow_workflow_state.action_id "
           + "order by nflow_workflow_state.action_id, nflow_workflow_state.state_key asc";
+      return jdbc.query(sql, new WorkflowActionStateRowMapper(), instance.id, instance.id);
     }
-    return jdbc.query(sql, new WorkflowActionStateRowMapper(), instance.id, instance.id);
   }
 
   @Transactional(propagation = MANDATORY)


### PR DESCRIPTION
**Background:** 

With the number of actions growing for a workflow in `nflow_workflow_actions` and `nflow_workflow_states` tables, a workflow can no longer load on nflow ui, because below end point timesout -

`/nflow/api/v1/workflow-instance/id/{workflowId}?include=actions,currentStateVariables,actionStateVariables`

With below state of cardinality of the table, it took 1 min 22 sec to get the result from the query this PR touches.
```
SHOW INDEX FROM nflow_workflow_state;
+----------------------+------------+----------+
| Column_name | Collation | Cardinality |
+----------------------+------------+----------+
| workflow_id | A         |     3762445 |
| action_id   | A         |     7524890 |
| state_key   | A         |     7524890 |
```


**Solution**

This PR adds `workflow_id` to the query so that only those action_id are processed which corresponds to the given workflow_id.

**Result**
With this change, The response from query was returned in ~ 1 sec.
 