### PR TITLE
Allow generics inside Mutable. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
   - Workflow instance actions and state variables that are older than 45 days are automatically cleaned up occasionally when the instance is processed. Use workflow settings to change the default time period (`setHistoryDeletableAfter`) and condition (`setDeleteHistoryCondition`) of the clean-up.
   - Add support to query also archived workflow instances when not enough non-archived matches are found.
   - Add `WorkflowInstance.Builder.setState(WorkflowState)` convenience method.
+  - Detect state methods with duplicate @StateVar names
+  - Allow simple generics objects in Mutable state variables
+  - Support instantiating Collection,List and Map interfaces to empty in state variables
   - Dependency updates
     - logback-classic update to version 1.2.11
       - <http://mailman.qos.ch/pipermail/announce/2021/000164.html>

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowStateProcessorTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowStateProcessorTest.java
@@ -665,6 +665,7 @@ public class WorkflowStateProcessorTest extends BaseNflowTest {
     assertThat(state.get("nullPojo"), is("{\"field\":\"magical instance\",\"test\":false}"));
     assertThat(state.get("immutablePojo"), is("{\"field\": \"unmodified\"}"));
     assertThat(state.get("mutableString"), is("mutated"));
+    assertThat(state.get("genericsMutable"), is("{\"mutated\":\"true\"}"));
     assertThat(state.get("hello"), is("[1,2,3]"));
   }
 
@@ -1023,17 +1024,19 @@ public class WorkflowStateProcessorTest extends BaseNflowTest {
     public NextAction process(StateExecution execution, @StateVar("string") String s, @StateVar("int") int i,
         @StateVar("pojo") Pojo pojo, @StateVar(value = "nullPojo", instantiateIfNotExists = true) Pojo pojo2,
         @StateVar(value = "immutablePojo", readOnly = true) Pojo unmodifiablePojo, @StateVar("nullInt") int zero,
-        @StateVar("mutableString") Mutable<String> mutableString) {
+        @StateVar("mutableString") Mutable<String> mutableString,
+        @StateVar(value="genericsMutable", instantiateIfNotExists = true) Mutable<Map<String, String>> genericsMutable) {
       assertThat(execution.getWorkflowInstanceId(), is(1L));
       assertThat(execution.getWorkflowInstanceExternalId(), is(notNullValue()));
       Pojo pojo1 = execution.getVariable("pojo", Pojo.class);
       assertThat(pojo.field, is(pojo1.field));
       assertThat(pojo.test, is(pojo1.test));
-      lastArgs = asList(s, i, pojo, pojo2, unmodifiablePojo, zero, mutableString.val);
+      lastArgs = asList(s, i, pojo, pojo2, unmodifiablePojo, zero, mutableString.val, genericsMutable.val);
       pojo.field += " modified";
       pojo2.field = "magical instance";
       unmodifiablePojo.field += " ignored";
       mutableString.val = "mutated";
+      genericsMutable.val.put("mutated", "true");
       execution.setVariable("hello", new int[] { 1, 2, 3 });
       return stopInState(TestState.DONE, "Finished");
     }


### PR DESCRIPTION
Check for duplicate state var names.
Add instantiation for common collection interfaces

Fixes #527 