### PR TITLE
Support loading workflow definitions from database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,15 @@
 **Details**
 
 - `nflow-engine`
-  - Add support to manage (create, update and read, but not execute) workflow instances without having the workflow implementation classes in the classpath.
+  - Add support to manage (create, update and read, but not execute) workflow instances without having the workflow implementation classes in the classpath. [#53](https://github.com/NitorCreations/nflow/pull/531)
     - If a workflow definition is not found from the classpath, it is loaded from the database and stored in memory.
-    - Workflow definitions that are loaded from the database are refreshed at most at configured interval (`nflow.definition.loadMissingFromDatabaseSeconds`, default 60).
+    - Workflow definitions that are loaded from the database are refreshed at most at configured interval (`nflow.definition.refreshStoredFromDatabase.interval.seconds`, default 60). Set to -1 to revert to previous functionality.
     - Potential use cases:
       - Creating workflow instances in a separate application that does not need to be updated when the workflow implementations are changed
       - Generic nFlow REST service that does not need to be updated when the workflow implementations or definitions are changed
       - Having a cluster of nFlow executors that just execute the workflows and have no other business logic
+    - Potential change break in functionality:
+      - If your code relied on the fact can workflows cannot be manipulated after their code is removed from classpath this change will break that guarantee, unless you disable this feature.
   - Improve shutdown sequence.
     - Workflows that were acquired from the database but have not started executing can now be resumed immediately by another executor.
     - Executing workflows are interrupted 5 seconds before shutdown timeout so that they get a chance to persist their state to the database. This also allows other executors to immediately resume the processing of the successfully interrupted workflows. The interrupting can be disabled by setting `nflow.executor.interrupt` to false.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 **Highlights**
 
 - `nflow-engine`
+  - Supports most functionality (insert/query) without workflow implementation code in classpath. Only executing requires the actual code.
+    - You can thus embed the engine in another JVM that just inserts the workflows.
+    - Or expose a generic nflow REST service that does not need to be updated whenever workflow implementations change.
   - Clean up old workflow executors that have expired configured time ago (default 1 year).
   - Optimize SQL queries used for dead node detection and workflow instance recovery.
   - Add `recovered` timestamp to executor info (database, Java API and REST API).
@@ -14,6 +17,7 @@
 **Details**
 
 - `nflow-engine`
+  - Supports load missing workflow definitions on-demand from database if one cannot be found locally from classpath. This allows insert/query/update of workflow instances, but not executing them. This maximum frequency of database scan can be controlled with `nflow.definition.loadMissingFromDatabaseSeconds`, which has default value of 60.
   - Improve shutdown sequence.
     - Workflows that were acquired from the database but have not started executing can now be resumed immediately by another executor.
     - Executing workflows are interrupted 5 seconds before shutdown timeout so that they get a chance to persist their state to the database. This also allows other executors to immediately resume the processing of the successfully interrupted workflows. The interrupting can be disabled by setting `nflow.executor.interrupt` to false.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 **Highlights**
 
 - `nflow-engine`
-  - Supports most functionality (insert/query) without workflow implementation code in classpath. Only executing requires the actual code.
-    - You can thus embed the engine in another JVM that just inserts the workflows.
-    - Or expose a generic nflow REST service that does not need to be updated whenever workflow implementations change.
+  - Add support to manage workflow instances without having the workflow implementation classes in the classpath.
   - Clean up old workflow executors that have expired configured time ago (default 1 year).
   - Optimize SQL queries used for dead node detection and workflow instance recovery.
   - Add `recovered` timestamp to executor info (database, Java API and REST API).
@@ -17,7 +15,13 @@
 **Details**
 
 - `nflow-engine`
-  - Supports load missing workflow definitions on-demand from database if one cannot be found locally from classpath. This allows insert/query/update of workflow instances, but not executing them. This maximum frequency of database scan can be controlled with `nflow.definition.loadMissingFromDatabaseSeconds`, which has default value of 60.
+  - Add support to manage (create, update and read, but not execute) workflow instances without having the workflow implementation classes in the classpath.
+    - If a workflow definition is not found from the classpath, it is loaded from the database and stored in memory.
+    - Workflow definitions that are loaded from the database are refreshed at most at configured interval (`nflow.definition.loadMissingFromDatabaseSeconds`, default 60).
+    - Potential use cases:
+      - Creating workflow instances in a separate application that does not need to be updated when the workflow implementations are changed
+      - Generic nFlow REST service that does not need to be updated when the workflow implementations or definitions are changed
+      - Having a cluster of nFlow executors that just execute the workflows and have no other business logic
   - Improve shutdown sequence.
     - Workflows that were acquired from the database but have not started executing can now be resumed immediately by another executor.
     - Executing workflows are interrupted 5 seconds before shutdown timeout so that they get a chance to persist their state to the database. This also allows other executors to immediately resume the processing of the successfully interrupted workflows. The interrupting can be disabled by setting `nflow.executor.interrupt` to false.

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
@@ -87,7 +87,7 @@ public abstract class DatabaseConfiguration {
     config.setPassword(property(env, "password"));
     config.setMaximumPoolSize(property(env, "max_pool_size", Integer.class));
     config.setIdleTimeout(property(env, "idle_timeout_seconds", Long.class) * 1000);
-    config.setAutoCommit(true);
+    config.setInitializationFailTimeout(property(env, "initialization_fail_timeout_seconds", Long.class) * 1000);
     if (metricRegistry != null) {
       config.setMetricRegistry(metricRegistry);
     }

--- a/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/db/DatabaseConfiguration.java
@@ -87,6 +87,7 @@ public abstract class DatabaseConfiguration {
     config.setPassword(property(env, "password"));
     config.setMaximumPoolSize(property(env, "max_pool_size", Integer.class));
     config.setIdleTimeout(property(env, "idle_timeout_seconds", Long.class) * 1000);
+    config.setAutoCommit(true);
     config.setInitializationFailTimeout(property(env, "initialization_fail_timeout_seconds", Long.class) * 1000);
     if (metricRegistry != null) {
       config.setMetricRegistry(metricRegistry);

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
@@ -47,6 +47,7 @@ public class WorkflowDispatcher implements Runnable {
   private final int stuckThreadThresholdSeconds;
   private final Random rand = new Random();
   private final boolean allowInterrupt;
+  private final boolean autoStart;
 
   @Inject
   @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "Transaction support exception message is fine")
@@ -63,7 +64,13 @@ public class WorkflowDispatcher implements Runnable {
     this.sleepTimeMillis = env.getRequiredProperty("nflow.dispatcher.sleep.ms", Long.class);
     this.stuckThreadThresholdSeconds = env.getRequiredProperty("nflow.executor.stuckThreadThreshold.seconds", Integer.class);
     this.allowInterrupt = env.getProperty("nflow.executor.interrupt", Boolean.class, TRUE);
+    this.autoStart = env.getRequiredProperty("nflow.autostart", Boolean.class);
+    if (autoStart) {
+      verifyDatabaseSetup();
+    }
+  }
 
+  private void verifyDatabaseSetup() {
     if (!executorDao.isTransactionSupportEnabled()) {
       throw new BeanCreationException("Transaction support must be enabled");
     }
@@ -74,9 +81,13 @@ public class WorkflowDispatcher implements Runnable {
 
   @Override
   public void run() {
-    logger.info("Dispacther started.");
     try {
+      if (!autoStart) {
+        verifyDatabaseSetup();
+      }
       workflowDefinitions.postProcessWorkflowDefinitions();
+
+      logger.info("Dispatcher started.");
       running.set(true);
       while (!shutdownRequested.get()) {
         if (paused.get()) {

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowDispatcher.java
@@ -50,7 +50,6 @@ public class WorkflowDispatcher implements Runnable {
   private final boolean autoStart;
 
   @Inject
-  @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "Transaction support exception message is fine")
   public WorkflowDispatcher(WorkflowInstanceExecutor executor, WorkflowInstanceDao workflowInstances,
       WorkflowStateProcessorFactory stateProcessorFactory, WorkflowDefinitionService workflowDefinitions, ExecutorDao executorDao,
       DispatcherExceptionAnalyzer exceptionAnalyzer, NflowLogger nflowLogger, Environment env) {
@@ -70,6 +69,7 @@ public class WorkflowDispatcher implements Runnable {
     }
   }
 
+  @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "Transaction support exception message is fine")
   private void verifyDatabaseSetup() {
     if (!executorDao.isTransactionSupportEnabled()) {
       throw new BeanCreationException("Transaction support must be enabled");

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import io.nflow.engine.internal.workflow.StoredWorkflowDefinitionWrapper;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
@@ -147,7 +148,7 @@ class WorkflowStateProcessor implements Runnable {
     WorkflowInstance instance = workflowInstances.getWorkflowInstance(instanceId, EnumSet.of(CURRENT_STATE_VARIABLES), null);
     logIfLagging(instance);
     WorkflowDefinition definition = workflowDefinitions.getWorkflowDefinition(instance.type);
-    if (definition == null) {
+    if (definition == null || definition instanceof StoredWorkflowDefinitionWrapper) {
       rescheduleUnknownWorkflowType(instance);
       return;
     }
@@ -217,11 +218,11 @@ class WorkflowStateProcessor implements Runnable {
   private void logRetryableException(StateProcessExceptionHandling exceptionHandling, String state, Throwable thrown) {
     if (exceptionHandling.logStackTrace) {
       nflowLogger.log(logger, exceptionHandling.logLevel, "Handling state '{}' threw a retryable exception, trying again later.",
-          new Object[] { state, thrown });
+              state, thrown);
     } else {
       nflowLogger.log(logger, exceptionHandling.logLevel,
           "Handling state '{}' threw a retryable exception, trying again later. Message: {}",
-          new Object[] { state, thrown.getMessage() });
+              state, thrown.getMessage());
     }
   }
 
@@ -317,11 +318,11 @@ class WorkflowStateProcessor implements Runnable {
         StateSaveExceptionHandling handling = stateSaveExceptionAnalyzer.analyzeSafely(ex, saveRetryCount++);
         if (handling.logStackTrace) {
           nflowLogger.log(logger, handling.logLevel, "Failed to save workflow instance {} new state, retrying after {} seconds.",
-              new Object[] { instance.id, handling.retryDelay, ex });
+                  instance.id, handling.retryDelay, ex);
         } else {
           nflowLogger.log(logger, handling.logLevel,
               "Failed to save workflow instance {} new state, retrying after {} seconds. Error: {}",
-              new Object[] { instance.id, handling.retryDelay, ex.getMessage() });
+                  instance.id, handling.retryDelay, ex.getMessage());
         }
         sleepIgnoreInterrupted(handling.retryDelay.getStandardSeconds());
       }

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinition.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinition.java
@@ -52,5 +52,4 @@ public class StoredWorkflowDefinition extends ModelObject {
       return value.compareTo(o.value);
     }
   }
-
 }

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinitionWrapper.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinitionWrapper.java
@@ -7,8 +7,6 @@ import io.nflow.engine.workflow.definition.WorkflowState;
 import io.nflow.engine.workflow.definition.WorkflowStateType;
 
 import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static io.nflow.engine.workflow.definition.WorkflowStateType.start;
 import static java.util.stream.Collectors.toList;
@@ -17,6 +15,11 @@ public class StoredWorkflowDefinitionWrapper extends WorkflowDefinition {
     public StoredWorkflowDefinitionWrapper(StoredWorkflowDefinition stored) {
         super(stored.type, getInitialState(stored), getErrorState(stored), new WorkflowSettings.Builder().build(), null, allStates(stored));
         setDescription(stored.description);
+    }
+
+    @Override
+    protected void requireStateMethodExists(WorkflowState state) {
+
     }
 
     private static Collection<WorkflowState> allStates(StoredWorkflowDefinition stored) {

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinitionWrapper.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinitionWrapper.java
@@ -1,0 +1,47 @@
+package io.nflow.engine.internal.workflow;
+
+import io.nflow.engine.internal.workflow.StoredWorkflowDefinition.State;
+import io.nflow.engine.workflow.definition.WorkflowDefinition;
+import io.nflow.engine.workflow.definition.WorkflowSettings;
+import io.nflow.engine.workflow.definition.WorkflowState;
+import io.nflow.engine.workflow.definition.WorkflowStateType;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.nflow.engine.workflow.definition.WorkflowStateType.start;
+import static java.util.stream.Collectors.toList;
+
+public class StoredWorkflowDefinitionWrapper extends WorkflowDefinition {
+    public StoredWorkflowDefinitionWrapper(StoredWorkflowDefinition stored) {
+        super(stored.type, getInitialState(stored), getErrorState(stored), new WorkflowSettings.Builder().build(), null, allStates(stored));
+        setDescription(stored.description);
+    }
+
+    private static Collection<WorkflowState> allStates(StoredWorkflowDefinition stored) {
+        return stored.states.stream().map(StoredWorkflowDefinitionWrapper::toState).collect(toList());
+    }
+
+    private static WorkflowState getInitialState(StoredWorkflowDefinition stored) {
+        for (State state : stored.states) {
+            if (start.name().equals(state.type)) {
+                return toState(state);
+            }
+        }
+        throw new IllegalStateException("Could not find initial state for " + stored);
+    }
+
+    private static WorkflowState toState(StoredWorkflowDefinition.State state) {
+        return new io.nflow.engine.workflow.curated.State(state.id, WorkflowStateType.valueOf(state.type), state.description);
+    }
+
+    private static WorkflowState getErrorState(StoredWorkflowDefinition stored) {
+        for (State state : stored.states) {
+            if (stored.onError.equals(state.id)) {
+                return toState(state);
+            }
+        }
+        throw new IllegalStateException("Could not find error state for " + stored);
+    }
+}

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinitionWrapper.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StoredWorkflowDefinitionWrapper.java
@@ -9,17 +9,13 @@ import io.nflow.engine.workflow.definition.WorkflowStateType;
 import java.util.Collection;
 
 import static io.nflow.engine.workflow.definition.WorkflowStateType.start;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 
 public class StoredWorkflowDefinitionWrapper extends WorkflowDefinition {
     public StoredWorkflowDefinitionWrapper(StoredWorkflowDefinition stored) {
-        super(stored.type, getInitialState(stored), getErrorState(stored), new WorkflowSettings.Builder().build(), null, allStates(stored));
+        super(stored.type, getInitialState(stored), getErrorState(stored), new WorkflowSettings.Builder().build(), emptyMap(), allStates(stored), false);
         setDescription(stored.description);
-    }
-
-    @Override
-    protected void requireStateMethodExists(WorkflowState state) {
-
     }
 
     private static Collection<WorkflowState> allStates(StoredWorkflowDefinition stored) {

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -51,7 +51,7 @@ public class WorkflowDefinitionService {
     this.workflowDefinitionDao = workflowDefinitionDao;
     this.persistWorkflowDefinitions = env.getRequiredProperty("nflow.definition.persist", Boolean.class);
     this.autoInit = env.getRequiredProperty("nflow.autoinit", Boolean.class);
-    this.storedDefinitionCheckInterval = SECONDS.toMillis(env.getRequiredProperty("nflow.definition.load.interval.seconds", Integer.class));
+    this.storedDefinitionCheckInterval = SECONDS.toMillis(env.getRequiredProperty("nflow.definition.loadMissingFromDatabase.interval.seconds", Integer.class));
     this.nextCheckOfStoredDefinitions = storedDefinitionCheckInterval > 0 ? 0 : MAX_VALUE;
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -51,7 +51,7 @@ public class WorkflowDefinitionService {
     this.workflowDefinitionDao = workflowDefinitionDao;
     this.persistWorkflowDefinitions = env.getRequiredProperty("nflow.definition.persist", Boolean.class);
     this.autoInit = env.getRequiredProperty("nflow.autoinit", Boolean.class);
-    this.storedDefinitionCheckInterval = SECONDS.toMillis(env.getProperty("nflow.definition.load.interval", Integer.class, 60));
+    this.storedDefinitionCheckInterval = SECONDS.toMillis(env.getRequiredProperty("nflow.definition.load.interval.seconds", Integer.class));
     this.nextCheckOfStoredDefinitions = storedDefinitionCheckInterval > 0 ? 0 : MAX_VALUE;
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -51,7 +51,7 @@ public class WorkflowDefinitionService {
     this.workflowDefinitionDao = workflowDefinitionDao;
     this.persistWorkflowDefinitions = env.getRequiredProperty("nflow.definition.persist", Boolean.class);
     this.autoInit = env.getRequiredProperty("nflow.autoinit", Boolean.class);
-    this.storedDefinitionCheckInterval = SECONDS.toMillis(env.getRequiredProperty("nflow.definition.loadMissingFromDatabase.interval.seconds", Integer.class));
+    this.storedDefinitionCheckInterval = SECONDS.toMillis(env.getRequiredProperty("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", Integer.class));
     this.nextCheckOfStoredDefinitions = storedDefinitionCheckInterval > 0 ? 0 : MAX_VALUE;
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -42,11 +42,11 @@ public class WorkflowDefinitionService {
   private final WorkflowDefinitionDao workflowDefinitionDao;
   private final boolean persistWorkflowDefinitions;
   private final boolean autoInit;
+  private final long storedDefinitionCheckInterval;
   /**
    * The next time the stored definitions from database are checked for changes.
    */
   private long nextCheckOfStoredDefinitions;
-  private final long storedDefinitionCheckInterval;
 
   @Inject
   public WorkflowDefinitionService(WorkflowDefinitionDao workflowDefinitionDao, Environment env) {

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.nflow.engine.internal.workflow.StoredWorkflowDefinition;
 import io.nflow.engine.internal.workflow.StoredWorkflowDefinitionWrapper;
 import org.slf4j.Logger;
@@ -127,6 +128,7 @@ public class WorkflowDefinitionService {
     }
   }
 
+  @SuppressFBWarnings(value="NOS_NON_OWNED_SYNCHRONIZATION", justification = "synchronize(this) is valid and needed to match the below synchronized refreshStoredDefinitions() method")
   private long needsWorkflowDefinitionRefresh() {
     if (storedDefinitionCheckInterval <= 0) {
       return -1;

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -119,7 +119,7 @@ public class WorkflowDefinitionService {
 
   private synchronized void refreshStoredDefinitions() {
     long now = currentTimeMillis();
-    if (nextCheckOfStoredDefinitions > now) {
+    if (storedDefinitionCheckInterval <= 0 || nextCheckOfStoredDefinitions > now) {
       return;
     }
     nextCheckOfStoredDefinitions = now + storedDefinitionCheckInterval;

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -114,9 +114,6 @@ public class WorkflowDefinitionService {
     logger.info("Added workflow type: {} ({})", wd.getType(), wd.getClass().getName());
   }
 
-  /**
-   *
-   */
   private synchronized void refreshStoredDefinitions() {
     long now = currentTimeMillis();
     if (nextCheckOfStoredDefinitions > now) {

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowDefinitionService.java
@@ -52,9 +52,8 @@ public class WorkflowDefinitionService {
     this.workflowDefinitionDao = workflowDefinitionDao;
     this.persistWorkflowDefinitions = env.getRequiredProperty("nflow.definition.persist", Boolean.class);
     this.autoInit = env.getRequiredProperty("nflow.autoinit", Boolean.class);
-    // TODO: config property name? also in CHANGES.md
     this.storedDefinitionCheckInterval = SECONDS
-        .toMillis(env.getRequiredProperty("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", Integer.class));
+        .toMillis(env.getRequiredProperty("nflow.definition.refreshStoredFromDatabase.interval.seconds", Integer.class));
     this.nextCheckOfStoredDefinitions = storedDefinitionCheckInterval > 0 ? 0 : MAX_VALUE;
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
@@ -116,6 +116,29 @@ public abstract class WorkflowDefinition extends ModelObject {
    *          The state methods to be used for the states of this workflow type. If null, the methods will be scanned.
    * @param states
    *          The states to be registered for the workflow. If null, the states will be scanned.
+   */
+  protected WorkflowDefinition(String type, WorkflowState initialState, WorkflowState errorState, WorkflowSettings settings,
+                               Map<String, WorkflowStateMethod> stateMethods, Collection<WorkflowState> states) {
+    this(type, initialState, errorState, settings, stateMethods, states, true);
+  }
+
+  /**
+   * Create a workflow definition with given settings, state methods and states.
+   *
+   * @param type
+   *          The unique identifier of this workflow definition.
+   * @param initialState
+   *          The default start state of the workflow. The state is automatically registered as one of the allowed states in this
+   *          workflow.
+   * @param errorState
+   *          The default error state of the workflow. The state is automatically registered as one of the allowed states in this
+   *          workflow.
+   * @param settings
+   *          The configuration for the workflow instances of this workflow type.
+   * @param stateMethods
+   *          The state methods to be used for the states of this workflow type. If null, the methods will be scanned.
+   * @param states
+   *          The states to be registered for the workflow. If null, the states will be scanned.
    * @param verifyStateMethodValidity
    *          True to search and verify the implementation of registered state methods to ensure they comply with expectations.
    */
@@ -135,7 +158,7 @@ public abstract class WorkflowDefinition extends ModelObject {
       this.stateMethods = scanner.getStateMethods(getClass());
     } else {
       if (!verifyStateMethodValidity) {
-        Assert.isTrue(stateMethods.isEmpty(), "Must enable validation if state methods providing");
+        Assert.isTrue(stateMethods.isEmpty(), "Must enable validation if state methods provided");
       }
       this.stateMethods = stateMethods;
     }

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
@@ -300,7 +300,7 @@ public abstract class WorkflowDefinition extends ModelObject {
     return settings;
   }
 
-  final void requireStateMethodExists(WorkflowState state) {
+  protected void requireStateMethodExists(WorkflowState state) {
     WorkflowStateMethod stateMethod = stateMethods.get(state.name());
     if (stateMethod == null && !state.getType().isFinal()) {
       String msg = format(
@@ -405,5 +405,4 @@ public abstract class WorkflowDefinition extends ModelObject {
   public Map<Integer, String> getSupportedSignals() {
     return emptyMap();
   }
-
 }

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
@@ -42,7 +42,7 @@ public abstract class WorkflowDefinition extends ModelObject {
   protected final Map<String, WorkflowState> failureTransitions = new LinkedHashMap<>();
   private Map<String, WorkflowStateMethod> stateMethods;
   private final Set<WorkflowState> states = new HashSet<>();
-  private boolean verifyStateMethodValidity;
+  private final boolean verifyStateMethodValidity;
 
   /**
    * Create a workflow definition with default settings and automatically scanned state methods.
@@ -154,11 +154,13 @@ public abstract class WorkflowDefinition extends ModelObject {
     this.verifyStateMethodValidity = verifyStateMethodValidity;
     WorkflowDefinitionScanner scanner = new WorkflowDefinitionScanner();
     if (stateMethods == null) {
-      Assert.isTrue(verifyStateMethodValidity, "Must enable validation if state methods are null and thus scanned");
+      Assert.isTrue(verifyStateMethodValidity,
+          "State method validity verification must be enabled when given state methods are null (scanned from classpath)");
       this.stateMethods = scanner.getStateMethods(getClass());
     } else {
       if (!verifyStateMethodValidity) {
-        Assert.isTrue(stateMethods.isEmpty(), "Must enable validation if state methods provided");
+        Assert.isTrue(stateMethods.isEmpty(),
+            "State method validity verification must be enabled when given state methods is not empty");
       }
       this.stateMethods = stateMethods;
     }

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -69,7 +69,7 @@ nflow.db.workflowInstanceType.cacheSize=10000
 nflow.db.initialization_fail_timeout_seconds=10
 
 nflow.definition.persist=true
-nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds=60
+nflow.definition.refreshStoredFromDatabase.interval.seconds=60
 
 nflow.maintenance.insertWorkflowIfMissing=true
 nflow.maintenance.initial.cron=4 4 4 * * *

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -69,7 +69,7 @@ nflow.db.workflowInstanceType.cacheSize=10000
 nflow.db.initialization_fail_timeout_seconds=10
 
 nflow.definition.persist=true
-nflow.definition.loadMissingFromDatabase.interval.seconds=60
+nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds=60
 
 nflow.maintenance.insertWorkflowIfMissing=true
 nflow.maintenance.initial.cron=4 4 4 * * *

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -68,7 +68,7 @@ nflow.db.disable_batch_updates=false
 nflow.db.workflowInstanceType.cacheSize=10000
 
 nflow.definition.persist=true
-nflow.definition.load=true
+nflow.definition.load.interval.seconds=60
 
 nflow.maintenance.insertWorkflowIfMissing=true
 nflow.maintenance.initial.cron=4 4 4 * * *

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -68,6 +68,7 @@ nflow.db.disable_batch_updates=false
 nflow.db.workflowInstanceType.cacheSize=10000
 
 nflow.definition.persist=true
+nflow.definition.load=true
 
 nflow.maintenance.insertWorkflowIfMissing=true
 nflow.maintenance.initial.cron=4 4 4 * * *

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -69,7 +69,7 @@ nflow.db.workflowInstanceType.cacheSize=10000
 nflow.db.initialization_fail_timeout_seconds=10
 
 nflow.definition.persist=true
-nflow.definition.load.interval.seconds=60
+nflow.definition.loadMissingFromDatabase.interval.seconds=60
 
 nflow.maintenance.insertWorkflowIfMissing=true
 nflow.maintenance.initial.cron=4 4 4 * * *

--- a/nflow-engine/src/main/resources/nflow-engine.properties
+++ b/nflow-engine/src/main/resources/nflow-engine.properties
@@ -66,6 +66,7 @@ nflow.db.idle_timeout_seconds=600
 nflow.db.create_on_startup=true
 nflow.db.disable_batch_updates=false
 nflow.db.workflowInstanceType.cacheSize=10000
+nflow.db.initialization_fail_timeout_seconds=10
 
 nflow.definition.persist=true
 nflow.definition.load.interval.seconds=60

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowDispatcherTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowDispatcherTest.java
@@ -102,6 +102,7 @@ public class WorkflowDispatcherTest {
     env.setProperty("nflow.executor.stateSaveRetryDelay.seconds", "60");
     env.setProperty("nflow.executor.stateVariableValueTooLongRetryDelay.minutes", "60");
     env.setProperty("nflow.db.workflowInstanceType.cacheSize", "10000");
+    env.setProperty("nflow.autostart", "true");
     when(executorDao.isTransactionSupportEnabled()).thenReturn(true);
     when(executorDao.isAutoCommitEnabled()).thenReturn(true);
     when(executorDao.isAutoCommitEnabled()).thenReturn(true);

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowDispatcherTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowDispatcherTest.java
@@ -320,10 +320,11 @@ public class WorkflowDispatcherTest {
             break;
           }
           assertThat(i, lessThan(10));
-          sleep(20);
+          sleep(50);
         }
         waitForTick(1);
         dispatcher.shutdown();
+        waitForTick(2);
       }
 
       @Override

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -139,6 +140,14 @@ public class WorkflowDefinitionServiceTest extends BaseNflowTest {
 
     assertThat(service.getWorkflowDefinition("notFound"), is(nullValue()));
     verify(workflowDefinitionDao).queryStoredWorkflowDefinitions(anyList());
+  }
+
+  @Test
+  public void getWorkflowDefinitionReturnsDoesNotQueryDatabaseIfCheckIntervalDisabled() {
+    initializeService(true, true, 0);
+
+    assertThat(service.getWorkflowDefinition("notFound"), is(nullValue()));
+    verify(workflowDefinitionDao, never()).queryStoredWorkflowDefinitions(anyList());
   }
 
   @Test

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
@@ -50,7 +50,7 @@ public class WorkflowDefinitionServiceTest extends BaseNflowTest {
   }
 
   private void initializeService(boolean definitionPersist, boolean autoInit, int reloadInterval) {
-    when(env.getRequiredProperty("nflow.definition.load.interval.seconds", Integer.class)).thenReturn(reloadInterval);
+    when(env.getRequiredProperty("nflow.definition.loadMissingFromDatabase.interval.seconds", Integer.class)).thenReturn(reloadInterval);
     when(env.getRequiredProperty("nflow.definition.persist", Boolean.class)).thenReturn(definitionPersist);
     when(env.getRequiredProperty("nflow.autoinit", Boolean.class)).thenReturn(autoInit);
     service = new WorkflowDefinitionService(workflowDefinitionDao, env);

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
@@ -50,7 +50,7 @@ public class WorkflowDefinitionServiceTest extends BaseNflowTest {
   }
 
   private void initializeService(boolean definitionPersist, boolean autoInit, int reloadInterval) {
-    when(env.getRequiredProperty("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", Integer.class)).thenReturn(reloadInterval);
+    when(env.getRequiredProperty("nflow.definition.refreshStoredFromDatabase.interval.seconds", Integer.class)).thenReturn(reloadInterval);
     when(env.getRequiredProperty("nflow.definition.persist", Boolean.class)).thenReturn(definitionPersist);
     when(env.getRequiredProperty("nflow.autoinit", Boolean.class)).thenReturn(autoInit);
     service = new WorkflowDefinitionService(workflowDefinitionDao, env);

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
@@ -37,6 +37,7 @@ public class WorkflowDefinitionServiceTest extends BaseNflowTest {
   }
 
   private void initializeService(boolean definitionPersist, boolean autoInit) {
+    when(env.getProperty("nflow.definition.load", Boolean.class, true)).thenReturn(true);
     when(env.getRequiredProperty("nflow.definition.persist", Boolean.class)).thenReturn(definitionPersist);
     when(env.getRequiredProperty("nflow.autoinit", Boolean.class)).thenReturn(autoInit);
     service = new WorkflowDefinitionService(workflowDefinitionDao, env);

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
@@ -160,6 +160,7 @@ public class WorkflowDefinitionServiceTest extends BaseNflowTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void getWorkflowDefinitionChecksFromDaoIfNotFoundFromMemory() throws Exception {
     initializeService(true, true, 1);
 

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceTest.java
@@ -50,7 +50,7 @@ public class WorkflowDefinitionServiceTest extends BaseNflowTest {
   }
 
   private void initializeService(boolean definitionPersist, boolean autoInit, int reloadInterval) {
-    when(env.getRequiredProperty("nflow.definition.loadMissingFromDatabase.interval.seconds", Integer.class)).thenReturn(reloadInterval);
+    when(env.getRequiredProperty("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", Integer.class)).thenReturn(reloadInterval);
     when(env.getRequiredProperty("nflow.definition.persist", Boolean.class)).thenReturn(definitionPersist);
     when(env.getRequiredProperty("nflow.autoinit", Boolean.class)).thenReturn(autoInit);
     service = new WorkflowDefinitionService(workflowDefinitionDao, env);

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
@@ -58,7 +58,7 @@ public class WorkflowDefinitionServiceWithSpringTest {
     public Environment env() {
       return new MockEnvironment()
               .withProperty("nflow.definition.persist", "true")
-              .withProperty("nflow.definition.load.interval.seconds", "60")
+              .withProperty("nflow.definition.loadMissingFromDatabase.interval.seconds", "60")
               .withProperty("nflow.autoinit", "true");
     }
 

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
@@ -58,7 +58,7 @@ public class WorkflowDefinitionServiceWithSpringTest {
     public Environment env() {
       return new MockEnvironment()
               .withProperty("nflow.definition.persist", "true")
-              .withProperty("nflow.definition.loadMissingFromDatabase.interval.seconds", "60")
+              .withProperty("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", "60")
               .withProperty("nflow.autoinit", "true");
     }
 

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
@@ -56,7 +56,10 @@ public class WorkflowDefinitionServiceWithSpringTest {
     @Bean
     @Primary
     public Environment env() {
-      return new MockEnvironment().withProperty("nflow.definition.persist", "true").withProperty("nflow.autoinit", "true");
+      return new MockEnvironment()
+              .withProperty("nflow.definition.persist", "true")
+              .withProperty("nflow.definition.load.interval.seconds", "60")
+              .withProperty("nflow.autoinit", "true");
     }
 
     @Bean

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowDefinitionServiceWithSpringTest.java
@@ -58,7 +58,7 @@ public class WorkflowDefinitionServiceWithSpringTest {
     public Environment env() {
       return new MockEnvironment()
               .withProperty("nflow.definition.persist", "true")
-              .withProperty("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", "60")
+              .withProperty("nflow.definition.refreshStoredFromDatabase.interval.seconds", "60")
               .withProperty("nflow.autoinit", "true");
     }
 

--- a/nflow-engine/src/test/resources/junit.properties
+++ b/nflow-engine/src/test/resources/junit.properties
@@ -19,3 +19,4 @@ nflow.db.idle_timeout_seconds=600
 nflow.db.create_on_startup=true
 nflow.db.disable_batch_updates=false
 nflow.db.workflowInstanceType.cacheSize=10000
+nflow.db.initialization_fail_timeout_seconds=1

--- a/nflow-engine/src/test/resources/nflow-engine-test.properties
+++ b/nflow-engine/src/test/resources/nflow-engine-test.properties
@@ -1,2 +1,3 @@
 nflow.autostart=false
 nflow.executor.timeout.seconds=800
+nflow.db.initialization_fail_timeout_seconds=1

--- a/nflow-server-common/src/main/java/io/nflow/server/spring/NflowStandardEnvironment.java
+++ b/nflow-server-common/src/main/java/io/nflow/server/spring/NflowStandardEnvironment.java
@@ -1,6 +1,7 @@
 package io.nflow.server.spring;
 
 import static io.nflow.engine.config.Profiles.H2;
+import static java.lang.Boolean.FALSE;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -25,10 +26,14 @@ public class NflowStandardEnvironment extends StandardEnvironment {
     getPropertySources().addFirst(new MapPropertySource("override", overrideProperties));
     addExternalPropertyResource();
     String env = getProperty("env", "local");
-    addActiveProfile(env);
     addPropertyResource(env);
     addPropertyResource("common");
     addPropertyResource("nflow-server");
+    var clearProfiles = getProperty("clearProfiles", Boolean.class, FALSE);
+    if (clearProfiles) {
+      setActiveProfiles("ignore-environment-profiles");
+    }
+    addActiveProfile(env);
     String profiles = getProperty("profiles", String.class, "");
     for (String profile : profiles.split(",")) {
       if (!profile.trim().isEmpty()) {

--- a/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
@@ -32,7 +32,7 @@ public class CodelessEngineTest extends AbstractNflowTest {
           .prop("nflow.autoinit", "false")
           .prop("nflow.autostart", "false")
           .prop("nflow.db.create_on_startup", "true")
-          .prop("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", "1")
+          .prop("nflow.definition.refreshStoredFromDatabase.interval.seconds", "1")
           .prop("nflow.maintenance.insertWorkflowIfMissing", "false")
           .prop("nflow.db.h2.url", "jdbc:h2:mem:codelessenginetest;TRACE_LEVEL_FILE=4;DB_CLOSE_DELAY=-1")
           .build();

--- a/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
@@ -32,7 +32,7 @@ public class CodelessEngineTest extends AbstractNflowTest {
           .prop("nflow.autoinit", "false")
           .prop("nflow.autostart", "false")
           .prop("nflow.db.create_on_startup", "true")
-          .prop("nflow.definition.loadMissingFromDatabase.interval.seconds", "1")
+          .prop("nflow.definition.loadMissingFromDatabaseSeconds.interval.seconds", "1")
           .prop("nflow.maintenance.insertWorkflowIfMissing", "false")
           .prop("nflow.db.h2.url", "jdbc:h2:mem:codelessenginetest;TRACE_LEVEL_FILE=4;DB_CLOSE_DELAY=-1")
           .build();

--- a/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
@@ -32,7 +32,7 @@ public class CodelessEngineTest extends AbstractNflowTest {
           .prop("nflow.autoinit", "false")
           .prop("nflow.autostart", "false")
           .prop("nflow.db.create_on_startup", "true")
-          .prop("nflow.definition.load.interval.seconds", "1")
+          .prop("nflow.definition.loadMissingFromDatabase.interval.seconds", "1")
           .prop("nflow.maintenance.insertWorkflowIfMissing", "false")
           .prop("nflow.db.h2.url", "jdbc:h2:mem:codelessenginetest;TRACE_LEVEL_FILE=4;DB_CLOSE_DELAY=-1")
           .build();

--- a/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/CodelessEngineTest.java
@@ -1,0 +1,115 @@
+package io.nflow.tests;
+
+import io.nflow.rest.v1.msg.CreateWorkflowInstanceRequest;
+import io.nflow.rest.v1.msg.CreateWorkflowInstanceResponse;
+import io.nflow.rest.v1.msg.ListWorkflowDefinitionResponse;
+import io.nflow.tests.demo.workflow.Demo2Workflow;
+import io.nflow.tests.extension.NflowServerConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.nflow.tests.demo.workflow.Demo2Workflow.DEMO2_WORKFLOW_TYPE;
+import static io.nflow.tests.demo.workflow.TestState.DONE;
+import static java.time.Duration.ofSeconds;
+import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CodelessEngineTest extends AbstractNflowTest {
+
+  public static final NflowServerConfig server = new NflowServerConfig.Builder()
+          .springContextClass(EmptyConfiguration.class)
+          .prop("nflow.autoinit", "false")
+          .prop("nflow.autostart", "false")
+          .prop("nflow.db.create_on_startup", "true")
+          .prop("nflow.definition.load.interval.seconds", "1")
+          .prop("nflow.maintenance.insertWorkflowIfMissing", "false")
+          .prop("nflow.db.h2.url", "jdbc:h2:mem:codelessenginetest;TRACE_LEVEL_FILE=4;DB_CLOSE_DELAY=-1")
+          .build();
+
+  public static final AtomicReference<NflowServerConfig> codeServer = new AtomicReference<>();
+  private static CreateWorkflowInstanceResponse resp;
+
+  public CodelessEngineTest() {
+    super(server);
+  }
+
+  static class EmptyConfiguration {
+  }
+
+  static class CodeConfiguration {
+    @Bean
+    public Demo2Workflow demo2Workflow() {
+      return new Demo2Workflow();
+    }
+  }
+
+  @Test
+  @Order(1)
+  public void codelessServerHasNoWorkflowsDefinitions() {
+    ListWorkflowDefinitionResponse[] definitions = getWorkflowDefinitions();
+    assertWorkflowDefinitionExists(DEMO2_WORKFLOW_TYPE, definitions, false);
+  }
+
+  @Test
+  @Order(2)
+  public void startCodeServer() throws Exception {
+    server.setSpringContextClass(CodeConfiguration.class);
+    codeServer.set(server.anotherServer(Map.of("nflow.autoinit", "true", "nflow.autostart", "true")));
+    codeServer.get().before(getClass().getSimpleName());
+  }
+
+  @Test
+  @Order(3)
+  public void codelessServerSeesTheDefinition() throws Exception {
+    SECONDS.sleep(1);
+    ListWorkflowDefinitionResponse[] definitions = getWorkflowDefinitions();
+    assertWorkflowDefinitionExists(DEMO2_WORKFLOW_TYPE, definitions, true);
+  }
+
+  @Test
+  @Order(4)
+  public void codelessCanInsertWorkflow() {
+    var req = new CreateWorkflowInstanceRequest();
+    req.type = DEMO2_WORKFLOW_TYPE;
+    req.businessKey = "1";
+    req.stateVariables = singletonMap("test", 1);
+    resp = createWorkflowInstance(req);
+    assertThat(resp.id, notNullValue());
+  }
+
+  @Test
+  @Order(5)
+  public void pollWorkflowToComplete() {
+    assertThat(getWorkflowInstanceWithTimeout(resp.id, DONE.name(), ofSeconds(30)), notNullValue());
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    codeServer.get().after();
+  }
+
+  private void assertWorkflowDefinitionExists(String type, ListWorkflowDefinitionResponse[] definitions, boolean shouldExist) {
+    for (ListWorkflowDefinitionResponse def : definitions) {
+      if (type.equals(def.type)) {
+        if (shouldExist) {
+          return;
+        }
+        fail("Workflow definition " + type + " should not be found");
+      }
+    }
+    if (shouldExist) {
+      fail("Workflow definition " + type + " is missing");
+    }
+  }
+}

--- a/nflow-tests/src/test/java/io/nflow/tests/SkipAutoStartTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/SkipAutoStartTest.java
@@ -20,6 +20,8 @@ public class SkipAutoStartTest extends AbstractNflowTest {
       .prop("nflow.maintenance.insertWorkflowIfMissing", "false")
       .prop("nflow.db.initialization_fail_timeout_seconds", "-1")
       .prop("nflow.db.url", "jdbc:h2:/invalid/path/that/does/not/exist")
+      .clearProfiles()
+      .profiles("nflow.db.h2")
       .build();
 
   public SkipAutoStartTest() {

--- a/nflow-tests/src/test/java/io/nflow/tests/SkipAutoStartTest.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/SkipAutoStartTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import io.nflow.tests.extension.NflowServerConfig;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class SkipAutoStartTest extends AbstractNflowTest {
 
   // When nflow.autoinit, nflow.autostart, nflow.db.create_on_startup and nflow.maintenance.insertWorkflowIfMissing are false, no
@@ -19,6 +18,8 @@ public class SkipAutoStartTest extends AbstractNflowTest {
       .prop("nflow.autostart", "false")
       .prop("nflow.db.create_on_startup", "false")
       .prop("nflow.maintenance.insertWorkflowIfMissing", "false")
+      .prop("nflow.db.initialization_fail_timeout_seconds", "-1")
+      .prop("nflow.db.url", "jdbc:h2:/invalid/path/that/does/not/exist")
       .build();
 
   public SkipAutoStartTest() {
@@ -26,7 +27,6 @@ public class SkipAutoStartTest extends AbstractNflowTest {
   }
 
   @Test
-  @Order(1)
   public void startServerButNotNflow() {
     assertNotNull(server.getHttpAddress());
   }

--- a/nflow-tests/src/test/java/io/nflow/tests/extension/NflowServerConfig.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/extension/NflowServerConfig.java
@@ -29,6 +29,9 @@ public class NflowServerConfig {
         port = new AtomicReference<>(b.port);
         springContextClass = b.springContextClass;
         metrics = b.metrics;
+        if (b.clearProfiles) {
+            props.put("clearProfiles", true);
+        }
     }
 
     public static class Builder {
@@ -38,6 +41,8 @@ public class NflowServerConfig {
         Class<?> springContextClass;
         boolean metrics = false;
         final Map<String, Object> props = new LinkedHashMap<>();
+        boolean clearProfiles;
+
         {
             props.put("nflow.db.h2.tcp.port", "");
             props.put("nflow.db.h2.console.port", "");
@@ -72,6 +77,12 @@ public class NflowServerConfig {
             this.metrics = enableMetrics;
             return this;
         }
+
+        public Builder clearProfiles() {
+            this.clearProfiles = true;
+            return this;
+        }
+
         public NflowServerConfig build() {
             return new NflowServerConfig(this);
         }

--- a/nflow-tests/src/test/java/io/nflow/tests/extension/NflowServerConfig.java
+++ b/nflow-tests/src/test/java/io/nflow/tests/extension/NflowServerConfig.java
@@ -133,6 +133,9 @@ public class NflowServerConfig {
     }
 
     private void stopJetty() {
+        if (nflowJetty == null) {
+            return;
+        }
         try {
             nflowJetty.setStopTimeout(10000);
             nflowJetty.stop();


### PR DESCRIPTION
The maximum rate can be controller with `nflow.definition.loadMissingFromDatabaseSeconds` - default rate is once every 60 seconds. But the definitions are only loaded from database if needed, not constantly in the background.