### PR TITLE
Define maven.compiler.release=11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Enable maintenance (archiving and deleting old workflow instances) by default.
   - Enable workflow instance history clean-up (deleting old actions and state variables) by default.
   - Add support to query also archived workflow instances.
+  - Define `maven.compiler.release = 11`
 
 ### Details
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler.version}</version>
           <configuration>
+            <release>${jdk.version}</release>
             <source>${jdk.version}</source>
             <target>${jdk.version}</target>
             <compilerArgs>


### PR DESCRIPTION
Ensures that we are compiling using JDK 11 version of APIs. Also allows building when using JDK 17.

https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html
https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html