### PR TITLE
Provide engine ObjectMapper via custom interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
   - Remove obsolete mysql legacy ddl sql scripts.
   - Include generated mariadb.create.ddl.sql in sources.jar.
   - Added tests against Oracle now that there is a working docker image of Oracle XE
+- `nflow-rest-api`
+  - POTENTIALLY BREAKING CHANGE: Remove `@Primary` annotation from `nflowRestObjectMapper` in `RestConfiguration` to allow overriding default mapper. Spring Boot applications may need to define the mapper explicitly now.
 - `nflow-metrics`
   - export the nflow.database.type as a metric
 - `nflow-netty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,6 @@
   - Remove obsolete mysql legacy ddl sql scripts.
   - Include generated mariadb.create.ddl.sql in sources.jar.
   - Added tests against Oracle now that there is a working docker image of Oracle XE
-- `nflow-rest-api`
-  - POTENTIALLY BREAKING CHANGE: Remove `@Primary` annotation from `nflowRestObjectMapper` in `RestConfiguration` to allow overriding default mapper. Spring Boot applications may need to define the mapper explicitly now.
 - `nflow-metrics`
   - export the nflow.database.type as a metric
 - `nflow-netty`

--- a/nflow-engine/src/main/java/io/nflow/engine/config/EngineConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/config/EngineConfiguration.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static java.lang.Runtime.getRuntime;
 
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Supplier;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -25,6 +26,8 @@ import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 @Configuration
 @ComponentScan("io.nflow.engine")
 public class EngineConfiguration {
+
+  public interface EngineObjectMapperSupplier extends Supplier<ObjectMapper> {}
 
   /**
    * Creates a workflow instance executor for processing workflow instances.
@@ -62,11 +65,11 @@ public class EngineConfiguration {
    */
   @Bean
   @NFlow
-  public ObjectMapper nflowObjectMapper() {
+  public EngineObjectMapperSupplier nflowObjectMapper() {
     ObjectMapper mapper = new ObjectMapper();
     mapper.setSerializationInclusion(NON_EMPTY);
     mapper.registerModule(new JodaModule());
-    return mapper;
+    return () -> mapper;
   }
 
   /**

--- a/nflow-engine/src/main/java/io/nflow/engine/guice/EngineModule.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/guice/EngineModule.java
@@ -21,12 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
 import io.nflow.engine.config.EngineConfiguration;
+import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
 import io.nflow.engine.config.NFlow;
 import io.nflow.engine.config.db.DatabaseConfiguration;
 import io.nflow.engine.config.db.Db2DatabaseConfiguration;
@@ -95,8 +95,8 @@ public class EngineModule extends AbstractModule {
   @Provides
   @NFlow
   @Singleton
-  public ObjectMapper nflowObjectMapper() {
-    return engineConfiguration.nflowObjectMapper();
+  public EngineObjectMapperSupplier nflowObjectMapper() {
+    return () -> engineConfiguration.nflowObjectMapper().get();
   }
 
   @Provides

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowDefinitionDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowDefinitionDao.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
 import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
@@ -52,11 +53,11 @@ public class WorkflowDefinitionDao {
   @Inject
   public WorkflowDefinitionDao(SQLVariants sqlVariants,
                                @NFlow NamedParameterJdbcTemplate nflowNamedParameterJdbcTemplate,
-                               @NFlow ObjectMapper nflowObjectMapper,
+                               @NFlow EngineObjectMapperSupplier nflowObjectMapper,
                                ExecutorDao executorDao) {
     this.sqlVariants = sqlVariants;
     this.namedJdbc = nflowNamedParameterJdbcTemplate;
-    this.nflowObjectMapper = nflowObjectMapper;
+    this.nflowObjectMapper = nflowObjectMapper.get();
     this.executorInfo = executorDao;
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 
+import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
 import jakarta.inject.Inject;
 
 import org.springframework.stereotype.Component;
@@ -24,8 +25,8 @@ public class ObjectStringMapper {
   private final ObjectMapper mapper;
 
   @Inject
-  public ObjectStringMapper(@NFlow ObjectMapper nflowObjectMapper) {
-    this.mapper = nflowObjectMapper;
+  public ObjectStringMapper(@NFlow EngineObjectMapperSupplier nflowObjectMapper) {
+    this.mapper = nflowObjectMapper.get();
   }
 
   @SuppressWarnings("unchecked")

--- a/nflow-engine/src/test/java/io/nflow/engine/config/EngineConfigurationTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/config/EngineConfigurationTest.java
@@ -70,7 +70,7 @@ public class EngineConfigurationTest {
 
   @Test
   public void nflowObjectMapperInstantiated() {
-    ObjectMapper mapper = configuration.nflowObjectMapper();
+    ObjectMapper mapper = configuration.nflowObjectMapper().get();
     assertThat(mapper.canSerialize(DateTime.class), is(true));
     assertThat(mapper.getSerializationConfig().getDefaultPropertyInclusion().getValueInclusion(),
         is(JsonInclude.Include.NON_EMPTY));

--- a/nflow-engine/src/test/java/io/nflow/engine/guice/EngineModuleTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/guice/EngineModuleTest.java
@@ -27,6 +27,7 @@ import com.google.inject.Key;
 import com.zaxxer.hikari.HikariDataSource;
 
 import io.nflow.engine.config.EngineConfiguration;
+import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
 import io.nflow.engine.config.NFlow;
 import io.nflow.engine.config.db.H2DatabaseConfiguration;
 import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
@@ -62,7 +63,7 @@ public class EngineModuleTest {
     assertThat(((CustomizableThreadFactory) factory).getThreadNamePrefix(), is("nflow-executor-"));
     assertThat(((CustomizableThreadFactory) factory).getThreadGroup().getName(), is("nflow"));
 
-    ObjectMapper mapper = injector.getInstance(Key.get(ObjectMapper.class, NFlow.class));
+    ObjectMapper mapper = injector.getInstance(Key.get(EngineObjectMapperSupplier.class, NFlow.class)).get();
     assertThat(mapper.canSerialize(DateTime.class), is(true));
     assertThat(mapper.getSerializationConfig().getDefaultPropertyInclusion().getValueInclusion(),
         is(JsonInclude.Include.NON_EMPTY));

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/DaoTestConfiguration.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/DaoTestConfiguration.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 import javax.sql.DataSource;
 
+import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
@@ -53,7 +54,7 @@ public class DaoTestConfiguration {
   @Bean
   public WorkflowDefinitionDao workflowDefinitionDao(SQLVariants sqlVariants,
                                                      @NFlow NamedParameterJdbcTemplate nflowNamedParameterJdbcTemplate,
-                                                     @NFlow ObjectMapper nflowObjectMapper,
+                                                     @NFlow EngineObjectMapperSupplier nflowObjectMapper,
                                                      ExecutorDao executorDao) {
     return new WorkflowDefinitionDao(sqlVariants,
             nflowNamedParameterJdbcTemplate,
@@ -94,11 +95,11 @@ public class DaoTestConfiguration {
 
   @Bean
   @NFlow
-  public ObjectMapper objectMapper() {
+  public EngineObjectMapperSupplier objectMapper() {
     ObjectMapper mapper = new ObjectMapper();
     mapper.setSerializationInclusion(NON_EMPTY);
     mapper.registerModule(new JodaModule());
-    return mapper;
+    return () -> mapper;
   }
 
   @Bean

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowStateProcessorTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowStateProcessorTest.java
@@ -176,7 +176,7 @@ public class WorkflowStateProcessorTest extends BaseNflowTest {
   @Captor
   ArgumentCaptor<List<WorkflowInstance>> workflows;
 
-  ObjectStringMapper objectMapper = new ObjectStringMapper(new ObjectMapper());
+  ObjectStringMapper objectMapper = new ObjectStringMapper(ObjectMapper::new);
 
   WorkflowStateProcessor executor;
 

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/ObjectStringMapperTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/ObjectStringMapperTest.java
@@ -20,7 +20,7 @@ import io.nflow.engine.workflow.definition.StateExecution;
 @ExtendWith(MockitoExtension.class)
 class ObjectStringMapperTest {
 
-  private final ObjectStringMapper mapper = new ObjectStringMapper(new ObjectMapper());
+  private final ObjectStringMapper mapper = new ObjectStringMapper(ObjectMapper::new);
 
   @Mock
   StateExecution execution;

--- a/nflow-examples/spring-boot/full-stack-kotlin/src/NflowApplication.kt
+++ b/nflow-examples/spring-boot/full-stack-kotlin/src/NflowApplication.kt
@@ -1,26 +1,18 @@
 package nflow.kotlin
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import io.nflow.engine.config.EngineConfiguration
-import io.nflow.engine.config.NFlow
 import io.nflow.engine.service.WorkflowInstanceService
 import io.nflow.engine.workflow.instance.WorkflowInstanceFactory
-import io.nflow.rest.config.NflowRestApiPropertiesConfiguration
 import io.nflow.rest.config.RestConfiguration
-import io.nflow.rest.config.RestConfiguration.REST_OBJECT_MAPPER
 import jakarta.inject.Inject
-import jakarta.inject.Named
 import nflow.kotlin.workflow.ExampleWorkflow
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.boot.runApplication
-import org.springframework.context.annotation.*
-import org.springframework.context.event.EventListener;
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.context.event.EventListener
 
-@Import(value = [EngineConfiguration::class, NflowRestApiPropertiesConfiguration::class])
-@ComponentScan(value = ["io.nflow.rest"], excludeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [RestConfiguration::class])])
+@Import(RestConfiguration::class)
 @Configuration
 class WorkflowAppConfig
 
@@ -40,14 +32,6 @@ class WorkflowApplication {
                 .setExternalId("example")
                 .putStateVariable(ExampleWorkflow.VAR_COUNTER, 0)
                 .build())
-    }
-
-    @Primary
-    @Bean
-    @Named(REST_OBJECT_MAPPER)
-    fun nflowRestObjectMapper(@NFlow nflowObjectMapper: ObjectMapper): ObjectMapper = nflowObjectMapper.copy().apply {
-        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-        enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
     }
 }
 

--- a/nflow-examples/spring-boot/full-stack/gradle/src/main/java/io/nflow/springboot/fullstack/gradle/DemoApplication.java
+++ b/nflow-examples/spring-boot/full-stack/gradle/src/main/java/io/nflow/springboot/fullstack/gradle/DemoApplication.java
@@ -1,33 +1,18 @@
 package io.nflow.springboot.fullstack.gradle;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.nflow.engine.config.EngineConfiguration;
-import io.nflow.engine.config.NFlow;
-import io.nflow.rest.config.NflowRestApiPropertiesConfiguration;
+import io.nflow.engine.service.WorkflowInstanceService;
+import io.nflow.engine.workflow.instance.WorkflowInstanceFactory;
 import io.nflow.rest.config.RestConfiguration;
 import jakarta.inject.Inject;
-
-import jakarta.inject.Named;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.event.EventListener;
 
-import io.nflow.engine.service.WorkflowInstanceService;
-import io.nflow.engine.workflow.instance.WorkflowInstanceFactory;
-
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_TRAILING_TOKENS;
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-import static io.nflow.rest.config.RestConfiguration.REST_OBJECT_MAPPER;
-
 @SpringBootApplication
-@Import({ EngineConfiguration.class, NflowRestApiPropertiesConfiguration.class })
-@ComponentScan(value = "io.nflow.rest", excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RestConfiguration.class))
+@Import(RestConfiguration.class)
 public class DemoApplication {
 
   @Inject
@@ -43,16 +28,6 @@ public class DemoApplication {
         .setExternalId("example")
         .putStateVariable(ExampleWorkflow.VAR_COUNTER, 0)
         .build());
-  }
-
-  @Primary
-  @Bean
-  @Named(REST_OBJECT_MAPPER)
-  public ObjectMapper nflowRestObjectMapper(@NFlow ObjectMapper nflowObjectMapper) {
-    ObjectMapper restObjectMapper = nflowObjectMapper.copy();
-    restObjectMapper.configure(WRITE_DATES_AS_TIMESTAMPS, false);
-    restObjectMapper.enable(FAIL_ON_TRAILING_TOKENS);
-    return restObjectMapper;
   }
 
   @Bean

--- a/nflow-examples/spring-boot/full-stack/maven/src/main/java/io/nflow/springboot/fullstack/maven/DemoApplication.java
+++ b/nflow-examples/spring-boot/full-stack/maven/src/main/java/io/nflow/springboot/fullstack/maven/DemoApplication.java
@@ -1,33 +1,18 @@
 package io.nflow.springboot.fullstack.maven;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.nflow.engine.config.EngineConfiguration;
-import io.nflow.engine.config.NFlow;
-import io.nflow.rest.config.NflowRestApiPropertiesConfiguration;
+import io.nflow.engine.service.WorkflowInstanceService;
+import io.nflow.engine.workflow.instance.WorkflowInstanceFactory;
 import io.nflow.rest.config.RestConfiguration;
 import jakarta.inject.Inject;
-
-import jakarta.inject.Named;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.event.EventListener;
 
-import io.nflow.engine.service.WorkflowInstanceService;
-import io.nflow.engine.workflow.instance.WorkflowInstanceFactory;
-
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_TRAILING_TOKENS;
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-import static io.nflow.rest.config.RestConfiguration.REST_OBJECT_MAPPER;
-
 @SpringBootApplication
-@Import({ EngineConfiguration.class, NflowRestApiPropertiesConfiguration.class })
-@ComponentScan(value = "io.nflow.rest", excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RestConfiguration.class))
+@Import(RestConfiguration.class)
 public class DemoApplication {
 
   @Inject
@@ -43,16 +28,6 @@ public class DemoApplication {
         .setExternalId("example")
         .putStateVariable(ExampleWorkflow.VAR_COUNTER, 0)
         .build());
-  }
-
-  @Primary
-  @Bean
-  @Named(REST_OBJECT_MAPPER)
-  public ObjectMapper nflowRestObjectMapper(@NFlow ObjectMapper nflowObjectMapper) {
-    ObjectMapper restObjectMapper = nflowObjectMapper.copy();
-    restObjectMapper.configure(WRITE_DATES_AS_TIMESTAMPS, false);
-    restObjectMapper.enable(FAIL_ON_TRAILING_TOKENS);
-    return restObjectMapper;
   }
 
   @Bean

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/config/RestConfiguration.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/config/RestConfiguration.java
@@ -2,21 +2,17 @@ package io.nflow.rest.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nflow.engine.config.EngineConfiguration;
+import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
 import io.nflow.engine.config.NFlow;
 import jakarta.inject.Named;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_TRAILING_TOKENS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 
-/**
- * This configuration configures default ObjectMapper to use. If you don't want to use it
- * you can import {@link EngineConfiguration} and define primary ObjectMapper nflowRestObjectMapper bean.
- */
 @Configuration
 @Import({ EngineConfiguration.class, NflowRestApiPropertiesConfiguration.class })
 @ComponentScan("io.nflow.rest")
@@ -24,11 +20,10 @@ public class RestConfiguration {
 
   public static final String REST_OBJECT_MAPPER = "nflowRestObjectMapper";
 
-  @Primary
   @Bean
   @Named(REST_OBJECT_MAPPER)
-  public ObjectMapper nflowRestObjectMapper(@NFlow ObjectMapper nflowObjectMapper) {
-    ObjectMapper restObjectMapper = nflowObjectMapper.copy();
+  public ObjectMapper nflowRestObjectMapper(@NFlow EngineObjectMapperSupplier nflowObjectMapper) {
+    ObjectMapper restObjectMapper = nflowObjectMapper.get().copy();
     restObjectMapper.configure(WRITE_DATES_AS_TIMESTAMPS, false);
     restObjectMapper.enable(FAIL_ON_TRAILING_TOKENS);
     return restObjectMapper;

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/config/RestConfiguration.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/config/RestConfiguration.java
@@ -1,21 +1,22 @@
 package io.nflow.rest.config;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_TRAILING_TOKENS;
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nflow.engine.config.EngineConfiguration;
+import io.nflow.engine.config.NFlow;
 import jakarta.inject.Named;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_TRAILING_TOKENS;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 
-import io.nflow.engine.config.EngineConfiguration;
-import io.nflow.engine.config.NFlow;
-
+/**
+ * This configuration configures default ObjectMapper to use. If you don't want to use it
+ * you can import {@link EngineConfiguration} and define primary ObjectMapper nflowRestObjectMapper bean.
+ */
 @Configuration
 @Import({ EngineConfiguration.class, NflowRestApiPropertiesConfiguration.class })
 @ComponentScan("io.nflow.rest")
@@ -23,6 +24,7 @@ public class RestConfiguration {
 
   public static final String REST_OBJECT_MAPPER = "nflowRestObjectMapper";
 
+  @Primary
   @Bean
   @Named(REST_OBJECT_MAPPER)
   public ObjectMapper nflowRestObjectMapper(@NFlow ObjectMapper nflowObjectMapper) {

--- a/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/CreateWorkflowConverterTest.java
+++ b/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/CreateWorkflowConverterTest.java
@@ -27,7 +27,7 @@ import io.nflow.rest.v1.msg.CreateWorkflowInstanceResponse;
 public class CreateWorkflowConverterTest {
 
   @Spy
-  private final ObjectStringMapper objectMapper = new ObjectStringMapper(new ObjectMapper());
+  private final ObjectStringMapper objectMapper = new ObjectStringMapper(ObjectMapper::new);
 
   private CreateWorkflowConverter converter;
 

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/config/jaxrs/RestConfigurationTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/config/jaxrs/RestConfigurationTest.java
@@ -25,7 +25,7 @@ public class RestConfigurationTest {
 
   @Test
   public void nflowRestObjectMapperInstantiated() {
-    ObjectMapper restMapper = configuration.nflowRestObjectMapper(new ObjectMapper());
+    ObjectMapper restMapper = configuration.nflowRestObjectMapper(ObjectMapper::new);
     assertThat(restMapper.getSerializationConfig().hasSerializationFeatures(WRITE_DATES_AS_TIMESTAMPS.getMask()), is(false));
   }
 }

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
@@ -95,7 +95,7 @@ public class WorkflowInstanceResourceTest {
     resource = new WorkflowInstanceResource(workflowInstances, createWorkflowConverter, listWorkflowConverter,
         workflowInstanceFactory, workflowInstanceDao);
     lenient().when(workflowInstanceFactory.newWorkflowInstanceBuilder())
-        .thenReturn(new WorkflowInstance.Builder(new ObjectStringMapper(new ObjectMapper())));
+        .thenReturn(new WorkflowInstance.Builder(new ObjectStringMapper(ObjectMapper::new)));
   }
 
   @Test


### PR DESCRIPTION
Provide `ObjectMapper` defined in `EngineConfiguration` via custom interface to avoid collision with the one in `RestConfiguration` and remove need for `Primary` annotation usage.