### PR TITLE
Add an http status check on form updates as they default to success when it could fail

### DIFF
--- a/nflow-explorer/src/workflow-instance/manage/UpdateWorkflowInstanceSignalForm.tsx
+++ b/nflow-explorer/src/workflow-instance/manage/UpdateWorkflowInstanceSignalForm.tsx
@@ -25,7 +25,10 @@ const UpdateWorkflowInstanceSignalForm = function (props: {
       signal: values.signal,
       reason: values.reason
     }).then((reason: any) => {
-      if (reason.error) {
+      if (!reason.ok) {
+        setErrorMsg(`HTTP error! status: ${reason.status}`);
+        setConfirmationMsg('');
+      } else if (reason.error) {
         setErrorMsg(reason.error);
         setConfirmationMsg('');
       } else {

--- a/nflow-explorer/src/workflow-instance/manage/UpdateWorkflowInstanceStateForm.tsx
+++ b/nflow-explorer/src/workflow-instance/manage/UpdateWorkflowInstanceStateForm.tsx
@@ -26,7 +26,10 @@ const UpdateWorkflowInstanceStateForm = function (props: {
       ),
       actionDescription: values.actionDescription
     }).then((reason: any) => {
-      if (reason.error) {
+      if (!reason.ok) {
+        setErrorMsg(`HTTP error! status: ${reason.status}`);
+        setConfirmationMsg('');
+      } else if (reason.error) {
         setErrorMsg(reason.error);
         setConfirmationMsg('');
       } else {

--- a/nflow-explorer/src/workflow-instance/manage/UpdateWorkflowInstanceStateVariableForm.tsx
+++ b/nflow-explorer/src/workflow-instance/manage/UpdateWorkflowInstanceStateVariableForm.tsx
@@ -23,7 +23,10 @@ const UpdateWorkflowInstanceStateVariableForm = function (props: {
       },
       actionDescription: values.actionDescription
     }).then((reason: any) => {
-      if (reason.error) {
+      if (!reason.ok) {
+        setErrorMsg(`HTTP error! status: ${reason.status}`);
+        setConfirmationMsg('');
+      } else if (reason.error) {
         setErrorMsg(reason.error);
         setConfirmationMsg('');
       } else {


### PR DESCRIPTION
with reference to this issue logged

https://github.com/NitorCreations/nflow/issues/629


Below screenshots showing the behaviour after the change

![nflow_update_state_variable_http_error](https://github.com/NitorCreations/nflow/assets/15829080/645a0baf-0f92-48f9-9f74-91c2b282603d)

![nflow_update_state_http_error](https://github.com/NitorCreations/nflow/assets/15829080/466584a6-f771-41b7-ab19-1fe756a55991)

