### PR TITLE
nflow explorer | sort the state variables by key on the display

### DIFF
--- a/nflow-explorer/src/workflow-instance/StateVariableTable.tsx
+++ b/nflow-explorer/src/workflow-instance/StateVariableTable.tsx
@@ -11,11 +11,13 @@ function StateVariableTable(props: {instance: WorkflowInstance}) {
       </pre>
     );
   };
-  const columns = Object.keys(props.instance.stateVariables || {}).map(key => ({
-    field: key,
-    headerName: key,
-    fieldRender: renderValue
-  }));
+  const columns = Object.keys(props.instance.stateVariables || {})
+    .map(key => ({
+      field: key,
+      headerName: key,
+      fieldRender: renderValue
+    }))
+    .sort((a, b) => a.field.localeCompare(b.field));
 
   if (!props.instance.stateVariables) {
     return <Alert severity="info">No state variables</Alert>;


### PR DESCRIPTION
…/nflow/issues/638

ref the above issue, small change to display the state variables in order of the key, below examples after making the code change

![image](https://github.com/NitorCreations/nflow/assets/15829080/edd2c5b9-a52b-4fad-bdc4-1486034a290a)


![image](https://github.com/NitorCreations/nflow/assets/15829080/8f07ee88-5a52-4360-ad88-4192dceb3239)
