### PR TITLE
Add Azure AD support to Explorer

### DIFF
--- a/nflow-explorer/package-lock.json
+++ b/nflow-explorer/package-lock.json
@@ -8,6 +8,8 @@
       "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
+        "@azure/msal-browser": "^3.13.0",
+        "@azure/msal-react": "^2.0.15",
         "@fontsource/roboto": "^4.5.8",
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
@@ -66,6 +68,37 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.13.0.tgz",
+      "integrity": "sha512-fD906nmJei3yE7la6DZTdUtXKvpwzJURkfsiz9747Icv4pit77cegSm6prJTKLQ1fw4iiZzrrWwxnhMLrTf5gQ==",
+      "dependencies": {
+        "@azure/msal-common": "14.9.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
+      "integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-react": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-2.0.15.tgz",
+      "integrity": "sha512-WtZGPxA6rWqGhovmWPUXjUyKTp/TUa4Oekk6FSa9ldCayd1QzYT9XcoAEqA0EfT0Fx12KiNvJyDDKckBU6J/+Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.13.0",
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -22586,6 +22619,25 @@
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
+    },
+    "@azure/msal-browser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.13.0.tgz",
+      "integrity": "sha512-fD906nmJei3yE7la6DZTdUtXKvpwzJURkfsiz9747Icv4pit77cegSm6prJTKLQ1fw4iiZzrrWwxnhMLrTf5gQ==",
+      "requires": {
+        "@azure/msal-common": "14.9.0"
+      }
+    },
+    "@azure/msal-common": {
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
+      "integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg=="
+    },
+    "@azure/msal-react": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-2.0.15.tgz",
+      "integrity": "sha512-WtZGPxA6rWqGhovmWPUXjUyKTp/TUa4Oekk6FSa9ldCayd1QzYT9XcoAEqA0EfT0Fx12KiNvJyDDKckBU6J/+Q==",
+      "requires": {}
     },
     "@babel/code-frame": {
       "version": "7.22.13",

--- a/nflow-explorer/package.json
+++ b/nflow-explorer/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
+    "@azure/msal-browser": "^3.13.0",
+    "@azure/msal-react": "^2.0.15",
     "@fontsource/roboto": "^4.5.8",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",

--- a/nflow-explorer/public/config.js
+++ b/nflow-explorer/public/config.js
@@ -101,4 +101,19 @@ var Config = new function() {
    * ]
    */
   this.searchResultColumns = undefined;
+
+  /**
+   * Microsoft Authentication Library for JavaScript configuration. For more details, see:
+   * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/master/lib/msal-browser/docs/configuration.md
+   * this.msalConfig = {
+   *   auth: {
+   *     authority: "https://login.microsoftonline.com/ENTER_YOUR_TENANT_ID",
+   *     clientId: "ENTER_YOUR_APPLICATION_ID"
+   *   },
+   *   cache: {
+   *     cacheLocation: "localStorage"
+   *   }
+   * };
+   */
+  this.msalConfig = undefined;
 };

--- a/nflow-explorer/src/types.ts
+++ b/nflow-explorer/src/types.ts
@@ -1,3 +1,5 @@
+import {Configuration, PublicClientApplication} from "@azure/msal-browser";
+
 interface Endpoint {
   id: string;
   title: string;
@@ -25,6 +27,8 @@ interface Config {
   nflowLogoFile?: string;
   nflowLogoTitle?: string;
   searchResultColumns?: Array<ColumnConfig>;
+  msalConfig?: Configuration;
+  msalClient?: PublicClientApplication;
 }
 
 interface Executor {


### PR DESCRIPTION
Add Azure AD support to the new Explorer.

If `msalConfig` is defined in `config.js`, force the user through Azure AD redirect-based login into the defined application when opening the Explorer. In the example configuration, credentials are cached in `localStorage` so they are available in different browser tabs as it's relatively normal to open multiple workflows to different tabs.

Because API calls are in a centralized `service.ts`, we cannot easily use `msal-react` hooks to access the authentication. Hence, the `msalClient` created in when opening Explorer is somewhat dirtily piggy-backed in `config`-object to `service.ts` and used to acquire and enrich the API calls with `Bearer`-token.

I haven't tested what happens if all the tokens (including refresh token) are expired. Probably an unclean failure, from which the user can recover by refreshing the browser and starting over. I don't have an environment where API is protected by Azure AD, so I just checked that the `Authorization` token is generated and set correctly.

So it's somewhat experimental support, but better than nothing and can be improved based on feedback.