### PR TITLE
Size check actions array in StateGraph

### DIFF
--- a/nflow-explorer/src/component/StateGraph.jsx
+++ b/nflow-explorer/src/component/StateGraph.jsx
@@ -44,6 +44,10 @@ function createGraph(props) {
     //when we have two actions in sequence that match the from state and the to state we return true
     const actions = instance.actions;
 
+    if (actions.length === 0) {
+      return false;
+    }
+
     for (let i = 0; i < actions.length - 1; i++) {
       // Check if the current action state matches the toState (since it's reversed)
       if (actions[i].state === toState && actions[i + 1].state === fromState) {


### PR DESCRIPTION
Actions can be empty for an instance for example  when creating a lot of workflows with no activation time, that are then managed by their parent workflow that activates them when more work is needed.

Without this check, these workflows waiting for activation crash the explorer.