### PR TITLE
Upgrade GHA ubuntu runner (20.04 retired)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         java: [ '17', '21' ]
         db: [ 'h2', 'mariadb', 'postgresql', 'mysql', 'sqlserver', 'db2', 'oracle' ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SPRING_PROFILES_ACTIVE: nflow.db.${{ matrix.db }}
       DB_VERSION: ${{ matrix.java == 17 && 'old' || 'latest' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         java: [ '17', '21' ]
         db: [ 'h2', 'mariadb', 'postgresql', 'mysql', 'sqlserver', 'db2', 'oracle' ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       SPRING_PROFILES_ACTIVE: nflow.db.${{ matrix.db }}
       DB_VERSION: ${{ matrix.java == 17 && 'old' || 'latest' }}

--- a/scripts/setup-db-sqlserver.sh
+++ b/scripts/setup-db-sqlserver.sh
@@ -18,6 +18,10 @@ esac
 
 $tool run --pull=always  --rm --name mssql -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=passWord1%' --publish 1433:1433 --detach mcr.microsoft.com/mssql/server:$DB_VERSION
 
+$tool logs mssql || true
+$tool inspect mssql || true
+$tool ps -a || true
+
 grep -F -m1 'Recovery is complete' <(timeout 240 $tool logs -f mssql 2>&1)
 
 sqlcmd="$tool exec -t mssql $SQLCMD_EXEC -S localhost -U sa -P passWord1% -e -x"

--- a/scripts/setup-db-sqlserver.sh
+++ b/scripts/setup-db-sqlserver.sh
@@ -15,15 +15,9 @@ case $DB_VERSION in
     ;;
 esac
 
-$tool run --pull=always --name mssql -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=passWord1%' --publish 1433:1433 --detach mcr.microsoft.com/mssql/server:$DB_VERSION
+$tool run --pull=always --rm --name mssql -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=passWord1%' --publish 1433:1433 --detach mcr.microsoft.com/mssql/server:$DB_VERSION
 
-sleep 10
-
-$tool logs mssql || true
-$tool inspect mssql || true
-$tool ps -a || true
-
-for i in {1..30}; do
+for i in {1..10}; do
   if $tool exec mssql $SQLCMD_EXEC -S localhost -U sa -P 'passWord1%' -Q 'SELECT 1' > /dev/null 2>&1; then
     echo "✅ SQL Server is ready"
     break
@@ -31,8 +25,6 @@ for i in {1..30}; do
   echo "⏳ Waiting for SQL Server..."
   sleep 5
 done
-
-$tool logs mssql || true
 
 sqlcmd="$tool exec -t mssql $SQLCMD_EXEC -S localhost -U sa -P passWord1% -e -x"
 $sqlcmd -Q "create database nflow"

--- a/scripts/setup-db-sqlserver.sh
+++ b/scripts/setup-db-sqlserver.sh
@@ -22,7 +22,7 @@ $tool logs mssql || true
 $tool inspect mssql || true
 $tool ps -a || true
 
-for i in {1..30}; do
+for i in {1..60}; do
   if $tool exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'passWord1%' -Q 'SELECT 1' > /dev/null 2>&1; then
     echo "✅ SQL Server is ready"
     break

--- a/scripts/setup-db-sqlserver.sh
+++ b/scripts/setup-db-sqlserver.sh
@@ -5,14 +5,13 @@ tool=$(command -v podman)
 [ -z "$tool" ] && echo "podman or docker required" && exit 1
 
 DB_VERSION=${DB_VERSION:-latest}
+SQLCMD_EXEC="/opt/mssql-tools18/bin/sqlcmd -C"
 case $DB_VERSION in
   old)
     DB_VERSION=2019-latest # supported until 2030
-    SQLCMD_EXEC=/opt/mssql-tools/bin/sqlcmd
     ;;
   latest)
     DB_VERSION=2022-latest
-    SQLCMD_EXEC="/opt/mssql-tools18/bin/sqlcmd -C"
     ;;
 esac
 
@@ -24,8 +23,8 @@ $tool logs mssql || true
 $tool inspect mssql || true
 $tool ps -a || true
 
-for i in {1..60}; do
-  if $tool exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'passWord1%' -Q 'SELECT 1' > /dev/null 2>&1; then
+for i in {1..30}; do
+  if $tool exec mssql $SQLCMD_EXEC -S localhost -U sa -P 'passWord1%' -Q 'SELECT 1' > /dev/null 2>&1; then
     echo "✅ SQL Server is ready"
     break
   fi

--- a/scripts/setup-db-sqlserver.sh
+++ b/scripts/setup-db-sqlserver.sh
@@ -7,7 +7,7 @@ tool=$(command -v podman)
 DB_VERSION=${DB_VERSION:-latest}
 case $DB_VERSION in
   old)
-    DB_VERSION=2017-latest # supported until 2027
+    DB_VERSION=2019-latest # supported until 2030
     SQLCMD_EXEC=/opt/mssql-tools/bin/sqlcmd
     ;;
   latest)

--- a/scripts/setup-db-sqlserver.sh
+++ b/scripts/setup-db-sqlserver.sh
@@ -22,7 +22,14 @@ $tool logs mssql || true
 $tool inspect mssql || true
 $tool ps -a || true
 
-grep -F -m1 'Recovery is complete' <(timeout 240 $tool logs -f mssql 2>&1)
+for i in {1..30}; do
+  if $tool exec mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'passWord1%' -Q 'SELECT 1' > /dev/null 2>&1; then
+    echo "✅ SQL Server is ready"
+    break
+  fi
+  echo "⏳ Waiting for SQL Server..."
+  sleep 5
+done
 
 sqlcmd="$tool exec -t mssql $SQLCMD_EXEC -S localhost -U sa -P passWord1% -e -x"
 $sqlcmd -Q "create database nflow"

--- a/scripts/setup-db-sqlserver.sh
+++ b/scripts/setup-db-sqlserver.sh
@@ -16,7 +16,9 @@ case $DB_VERSION in
     ;;
 esac
 
-$tool run --pull=always  --rm --name mssql -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=passWord1%' --publish 1433:1433 --detach mcr.microsoft.com/mssql/server:$DB_VERSION
+$tool run --pull=always --name mssql -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=passWord1%' --publish 1433:1433 --detach mcr.microsoft.com/mssql/server:$DB_VERSION
+
+sleep 10
 
 $tool logs mssql || true
 $tool inspect mssql || true
@@ -30,6 +32,8 @@ for i in {1..60}; do
   echo "⏳ Waiting for SQL Server..."
   sleep 5
 done
+
+$tool logs mssql || true
 
 sqlcmd="$tool exec -t mssql $SQLCMD_EXEC -S localhost -U sa -P passWord1% -e -x"
 $sqlcmd -Q "create database nflow"


### PR DESCRIPTION
https://github.com/NitorCreations/nflow/actions/runs/14509365685/job/40865457332

> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, > see https://github.com/actions/runner-images/issues/11101

Upgraded to Ubuntu 22.04 runner. Integration test with SQL Server 2017 uses Ubuntu 18.04, which does not work on Ubuntu 22.04 host, so using SQL Server 2019 instead as the "old" version.
