### PR TITLE
add missing resource tag in pom file

### DIFF
--- a/nflow-examples/spring-boot/full-stack/maven/pom.xml
+++ b/nflow-examples/spring-boot/full-stack/maven/pom.xml
@@ -45,6 +45,12 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
demo spring boot pom file is missing the resource tag, this results in the default file being used which has a static url and port 3000 so the spring boot port defaults to 8080 and wont work