### PR TITLE
Fix java test warnings

### DIFF
--- a/nflow-engine/src/main/java/io/nflow/engine/service/MaintenanceConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/MaintenanceConfiguration.java
@@ -19,27 +19,27 @@ public class MaintenanceConfiguration {
   /**
    * Configuration for archiving old workflow instances.
    */
-  public ConfigurationItem archiveWorkflows;
+  public final ConfigurationItem archiveWorkflows;
 
   /**
    * Configuration for deleting old workflow instances from archive tables.
    */
-  public ConfigurationItem deleteArchivedWorkflows;
+  public final ConfigurationItem deleteArchivedWorkflows;
 
   /**
    * Configuration for deleting old workflow instances from main tables.
    */
-  public ConfigurationItem deleteWorkflows;
+  public final ConfigurationItem deleteWorkflows;
 
   /**
    * Delete workflow executors that have expired [given period] ago.
    */
-  public ReadablePeriod deleteExpiredExecutorsOlderThan;
+  public final ReadablePeriod deleteExpiredExecutorsOlderThan;
 
   MaintenanceConfiguration(@JsonProperty("deleteArchivedWorkflows") ConfigurationItem deleteArchivedWorkflows,
       @JsonProperty("archiveWorkflows") ConfigurationItem archiveWorkflows,
       @JsonProperty("deleteWorkflows") ConfigurationItem deleteWorkflows,
-      @JsonProperty("deleteExpiredAfter") ReadablePeriod deleteExpiredExecutorsOlderThan) {
+      @JsonProperty("deleteExpiredExecutorsOlderThan") ReadablePeriod deleteExpiredExecutorsOlderThan) {
     this.deleteArchivedWorkflows = deleteArchivedWorkflows;
     this.archiveWorkflows = archiveWorkflows;
     this.deleteWorkflows = deleteWorkflows;
@@ -118,17 +118,17 @@ public class MaintenanceConfiguration {
     /**
      * Items older than (now - period) are processed.
      */
-    public ReadablePeriod olderThanPeriod;
+    public final ReadablePeriod olderThanPeriod;
 
     /**
      * The batch size of the maintenance operation.
      */
-    public int batchSize;
+    public final int batchSize;
 
     /**
      * The workflow types to be processed. If empty, process all types.
      */
-    public Set<String> workflowTypes;
+    public final Set<String> workflowTypes;
 
     ConfigurationItem(@JsonProperty("olderThanPeriod") ReadablePeriod olderThanPeriod,
         @JsonProperty("batchSize") Integer batchSize, @JsonProperty("workflowTypes") Set<String> workflowTypes) {

--- a/nflow-engine/src/main/java/io/nflow/engine/service/MaintenanceConfiguration.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/MaintenanceConfiguration.java
@@ -19,22 +19,22 @@ public class MaintenanceConfiguration {
   /**
    * Configuration for archiving old workflow instances.
    */
-  public final ConfigurationItem archiveWorkflows;
+  public ConfigurationItem archiveWorkflows;
 
   /**
    * Configuration for deleting old workflow instances from archive tables.
    */
-  public final ConfigurationItem deleteArchivedWorkflows;
+  public ConfigurationItem deleteArchivedWorkflows;
 
   /**
    * Configuration for deleting old workflow instances from main tables.
    */
-  public final ConfigurationItem deleteWorkflows;
+  public ConfigurationItem deleteWorkflows;
 
   /**
    * Delete workflow executors that have expired [given period] ago.
    */
-  public final ReadablePeriod deleteExpiredExecutorsOlderThan;
+  public ReadablePeriod deleteExpiredExecutorsOlderThan;
 
   MaintenanceConfiguration(@JsonProperty("deleteArchivedWorkflows") ConfigurationItem deleteArchivedWorkflows,
       @JsonProperty("archiveWorkflows") ConfigurationItem archiveWorkflows,
@@ -118,17 +118,17 @@ public class MaintenanceConfiguration {
     /**
      * Items older than (now - period) are processed.
      */
-    public final ReadablePeriod olderThanPeriod;
+    public ReadablePeriod olderThanPeriod;
 
     /**
      * The batch size of the maintenance operation.
      */
-    public final int batchSize;
+    public int batchSize;
 
     /**
      * The workflow types to be processed. If empty, process all types.
      */
-    public final Set<String> workflowTypes;
+    public Set<String> workflowTypes;
 
     ConfigurationItem(@JsonProperty("olderThanPeriod") ReadablePeriod olderThanPeriod,
         @JsonProperty("batchSize") Integer batchSize, @JsonProperty("workflowTypes") Set<String> workflowTypes) {

--- a/nflow-engine/src/test/java/io/nflow/engine/config/EngineConfigurationTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/config/EngineConfigurationTest.java
@@ -28,14 +28,14 @@ import io.nflow.engine.internal.executor.WorkflowInstanceExecutor;
 public class EngineConfigurationTest {
 
   @Spy
-  private final MockEnvironment environment = new MockEnvironment().withProperty("nflow.executor.thread.count", "100")
+  private MockEnvironment environment = new MockEnvironment().withProperty("nflow.executor.thread.count", "100")
       .withProperty("nflow.dispatcher.await.termination.seconds", "60")
       .withProperty("nflow.dispatcher.executor.thread.keepalive.seconds", "0");
   @Mock
   private ThreadFactory threadFactory;
 
   @InjectMocks
-  private final EngineConfiguration configuration = new EngineConfiguration();
+  private EngineConfiguration configuration = new EngineConfiguration();
 
   @Test
   public void dispatcherPoolExecutorInstantiationFromThreads() {

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowDispatcherTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/executor/WorkflowDispatcherTest.java
@@ -429,7 +429,7 @@ public class WorkflowDispatcherTest {
       debug(name + " waiting for tick " + wantedTick);
       waiters.computeIfAbsent(wantedTick, t -> synchronizedList(new ArrayList<>())).add(thread);
       for (int i=0; i<200; ++i) {
-        if (tick.get() == wantedTick) {
+        if (tick.get() >= wantedTick) {
           debug(name + " got tick " + wantedTick);
           waiters.get(wantedTick).remove(thread);
           return;
@@ -438,7 +438,7 @@ public class WorkflowDispatcherTest {
           synchronized (thread) {
             debug(name + " still waiting for tick " + wantedTick);
             thread.wait(100);
-            if (tick.get() == wantedTick) {
+            if (tick.get() >= wantedTick) {
               debug(name + " got tick " + wantedTick);
               waiters.get(wantedTick).remove(thread);
               return;

--- a/nflow-engine/src/test/java/io/nflow/engine/service/MaintenanceConfigurationDeserializationTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/MaintenanceConfigurationDeserializationTest.java
@@ -1,0 +1,55 @@
+package io.nflow.engine.service;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.joda.time.Period.days;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+
+import io.nflow.engine.service.MaintenanceConfiguration.ConfigurationItem;
+
+class MaintenanceConfigurationDeserializationTest {
+
+  private final ObjectMapper mapper;
+
+  MaintenanceConfigurationDeserializationTest() {
+    mapper = new ObjectMapper();
+    mapper.setDefaultPropertyInclusion(NON_EMPTY);
+    mapper.registerModule(new JodaModule());
+  }
+
+  @Test
+  void maintenanceConfigurationRoundTrip() throws Exception {
+    MaintenanceConfiguration original = new MaintenanceConfiguration.Builder()
+        .withArchiveWorkflows().setOlderThanPeriod(days(30)).setBatchSize(500).done()
+        .withDeleteArchivedWorkflows().setOlderThanPeriod(days(90)).setBatchSize(100).done()
+        .withDeleteExpiredExecutorsOlderThan(days(7))
+        .build();
+
+    String json = mapper.writeValueAsString(original);
+    MaintenanceConfiguration deserialized = mapper.readValue(json, MaintenanceConfiguration.class);
+
+    assertThat(deserialized.archiveWorkflows, notNullValue());
+    assertThat(deserialized.archiveWorkflows.batchSize, is(original.archiveWorkflows.batchSize));
+    assertThat(deserialized.deleteArchivedWorkflows, notNullValue());
+    assertThat(deserialized.deleteArchivedWorkflows.batchSize, is(original.deleteArchivedWorkflows.batchSize));
+  }
+
+  @Test
+  void configurationItemRoundTrip() throws Exception {
+    ConfigurationItem original = new MaintenanceConfiguration.Builder()
+        .withArchiveWorkflows().setOlderThanPeriod(days(30)).setBatchSize(200).done()
+        .build()
+        .archiveWorkflows;
+
+    String json = mapper.writeValueAsString(original);
+    ConfigurationItem deserialized = mapper.readValue(json, ConfigurationItem.class);
+
+    assertThat(deserialized.batchSize, is(original.batchSize));
+  }
+}

--- a/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/CreateWorkflowConverterTest.java
+++ b/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/CreateWorkflowConverterTest.java
@@ -27,7 +27,7 @@ import io.nflow.rest.v1.msg.CreateWorkflowInstanceResponse;
 public class CreateWorkflowConverterTest {
 
   @Spy
-  private final ObjectStringMapper objectMapper = new ObjectStringMapper(ObjectMapper::new);
+  private ObjectStringMapper objectMapper = new ObjectStringMapper(ObjectMapper::new);
 
   private CreateWorkflowConverter converter;
 

--- a/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/ListWorkflowInstanceConverterTest.java
+++ b/nflow-rest-api-common/src/test/java/io/nflow/rest/v1/converter/ListWorkflowInstanceConverterTest.java
@@ -47,7 +47,7 @@ public class ListWorkflowInstanceConverterTest {
   @Mock
   private ObjectMapper nflowObjectMapper;
   @InjectMocks
-  private final ListWorkflowInstanceConverter converter = new ListWorkflowInstanceConverter();
+  private ListWorkflowInstanceConverter converter = new ListWorkflowInstanceConverter();
 
   @Test
   public void convertWithActionsWorks() throws IOException {

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/MaintenanceResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/MaintenanceResourceTest.java
@@ -30,11 +30,11 @@ import io.nflow.rest.v1.msg.MaintenanceResponse;
 public class MaintenanceResourceTest {
 
   @InjectMocks
-  private final MaintenanceResource resource = new MaintenanceResource();
+  private MaintenanceResource resource = new MaintenanceResource();
   @Mock
   private MaintenanceService service;
   @Spy
-  private final MaintenanceConverter converter = new MaintenanceConverter();
+  private MaintenanceConverter converter = new MaintenanceConverter();
   @Captor
   private ArgumentCaptor<MaintenanceConfiguration> configCaptor;
 

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/StatisticsResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/StatisticsResourceTest.java
@@ -29,7 +29,7 @@ import io.nflow.rest.v1.msg.WorkflowDefinitionStatisticsResponse;
 public class StatisticsResourceTest {
 
   @InjectMocks
-  private final StatisticsResource resource = new StatisticsResource();
+  private StatisticsResource resource = new StatisticsResource();
   @Mock
   private StatisticsService service;
   @Mock

--- a/nflow-server-common/pom.xml
+++ b/nflow-server-common/pom.xml
@@ -52,7 +52,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.outputDirectory}/nflow-ui-assets/doc</outputDirectory>
-              <overwrite>false</overwrite>
+              <changeDetection>true</changeDetection>
               <resources>
                 <resource>
                   <directory>${project.build.directory}/swagger/swagger-ui-${swagger.ui.version}/dist</directory>
@@ -72,7 +72,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.outputDirectory}/nflow-ui-assets/explorer</outputDirectory>
-              <overwrite>false</overwrite>
+              <changeDetection>true</changeDetection>
               <resources>
                 <resource>
                   <directory>${project.basedir}/../nflow-explorer/build</directory>

--- a/nflow-server-common/pom.xml
+++ b/nflow-server-common/pom.xml
@@ -52,7 +52,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.outputDirectory}/nflow-ui-assets/doc</outputDirectory>
-              <changeDetection>true</changeDetection>
+              <changeDetection>content</changeDetection>
               <resources>
                 <resource>
                   <directory>${project.build.directory}/swagger/swagger-ui-${swagger.ui.version}/dist</directory>
@@ -72,7 +72,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.outputDirectory}/nflow-ui-assets/explorer</outputDirectory>
-              <changeDetection>true</changeDetection>
+              <changeDetection>content</changeDetection>
               <resources>
                 <resource>
                   <directory>${project.basedir}/../nflow-explorer/build</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
   <properties>
     <jdk.version>17</jdk.version>
     <jacocoArgLine></jacocoArgLine>
+    <java26ExtraArgs></java26ExtraArgs>
+    <guava.version>33.6.0-jre</guava.version>
     <surefire.forkcount>1C</surefire.forkcount>
     <asm.version>9.10</asm.version>
     <apache.cxf.version>4.2.1</apache.cxf.version>
@@ -217,7 +219,7 @@
             <perCoreThreadCount>true</perCoreThreadCount>
             <threadCount>1</threadCount>
             <forkCount>${surefire.forkcount}</forkCount>
-            <argLine>@{jacocoArgLine}</argLine>
+            <argLine>@{jacocoArgLine} ${java26ExtraArgs}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -465,6 +467,15 @@
   </build>
   <profiles>
     <profile>
+      <id>java26plus</id>
+      <activation>
+        <jdk>[26,)</jdk>
+      </activation>
+      <properties>
+        <java26ExtraArgs>--illegal-final-field-mutation=deny</java26ExtraArgs>
+      </properties>
+    </profile>
+    <profile>
       <activation>
         <jdk>17</jdk>
       </activation>
@@ -599,6 +610,12 @@
         <groupId>com.nitorcreations</groupId>
         <artifactId>core-utils</artifactId>
         <version>${core-utils.version}</version>
+      </dependency>
+      <!-- guava -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
       <!-- guice -->
       <dependency>


### PR DESCRIPTION
* Enable java 26 feature that throws an exception if a final field is mutated (default is currently to warn). This will become default in some next java release. But for now enabling it manually allows JVM to optimize code better, because it can trust that final fields are immutable (they were made mutable in java 1.4, so this feature/bug existed for 20+ years).
   * 1 bug in nflow-engine where constructor had wrong jackson annotation for deserialization which caused jackson to use reflection to clear the final flag from a field to modify it
    * remove final from fields that are modified by reflection
* some other warnings were fixed by upgrading guava library
* and there were also warnings by maven resources plugin deprecated parameter usage
* also hit a randomly occurring race condition in `WorkflowDispatcherTest` and tried to fix it
