### PR TITLE
Add expectedState transition validation to workflow updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@
   - Add optional expected state and state transition validations for workflow instance updates.
     - Add optional `expectedState` parameter to `WorkflowInstanceService.updateWorkflowInstance`; return `false` when expected state does not match the workflow instance state in the database.
     - Add optional `validationMode` parameter to `WorkflowInstanceService.updateWorkflowInstance`; return `false` when transition from expected state to requested new state is not allowed by the workflow definition.
-    - `validationMode` is ignored when `expectedState` is not given.
+    - `validationMode` must be `doNotValidate` when `expectedState` is not given.
     - Keep `WorkflowInstanceService.updateWorkflowInstance` that does not take `expectedState` and `validationMode` parameters to maintain backwards compatibility, but mark it as deprecated.
     - Add `WorkflowDefinition.isAllowedStateTransition` helper for checking allowed transitions.
 - `nflow-rest-api`
   - Add optional expected state and state transition validations for workflow instance updates.
     - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` when expected state does not match the workflow instance state in the database.
     - Workflow instance update endpoints now take optional `validationMode` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` when transition from expected state to requested new state is not allowed by the workflow definition.
-    - `validationMode` is ignored when `expectedState` is not given.
+    - `validationMode` must be `doNotValidate` when `expectedState` is not given.
 
 ## 10.0.2 (2026-05-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 **Details**
 
+- `nflow-engine`
+  - Add optional state transition validation for workflow instance updates.
+    - `WorkflowInstanceService.updateWorkflowInstance` now takes optional `expectedState` and returns `false` when transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
+    - Add `WorkflowDefinition.isAllowedStateTransition` helper for checking allowed transitions.
+- `nflow-rest-api`
+  - Add optional state transition validation for workflow instance updates.
+    - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
+
 ## 10.0.2 (2026-05-23)
 
 **Highlights**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 
 - `nflow-engine`
   - Add optional state transition validation for workflow instance updates.
-    - `WorkflowInstanceService.updateWorkflowInstance` now takes optional `expectedState` and returns `false` when transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
+    - Add `WorkflowInstanceService.updateWorkflowInstance` that takes optional `expectedState` and returns `false` when transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
+    - Keep `WorkflowInstanceService.updateWorkflowInstance` that does not take `expectedState` parameter to maintain backwards compatibility, but mark it as deprecated.
     - Add `WorkflowDefinition.isAllowedStateTransition` helper for checking allowed transitions.
 - `nflow-rest-api`
   - Add optional state transition validation for workflow instance updates.
-    - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
+    - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` when transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
 
 ## 10.0.2 (2026-05-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@
 **Details**
 
 - `nflow-engine`
-  - Add optional state transition validation for workflow instance updates.
-    - Add `WorkflowInstanceService.updateWorkflowInstance` that takes optional `expectedState` and returns `false` when transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
-    - Keep `WorkflowInstanceService.updateWorkflowInstance` that does not take `expectedState` parameter to maintain backwards compatibility, but mark it as deprecated.
+  - Add optional expected state and state transition validations for workflow instance updates.
+    - Add optional `expectedState` parameter to `WorkflowInstanceService.updateWorkflowInstance`; return `false` when expected state does not match the workflow instance state in the database.
+    - Add optional `validationMode` parameter to `WorkflowInstanceService.updateWorkflowInstance`; return `false` when transition from expected state to requested new state is not allowed by the workflow definition.
+    - `validationMode` is ignored when `expectedState` is not given.
+    - Keep `WorkflowInstanceService.updateWorkflowInstance` that does not take `expectedState` and `validationMode` parameters to maintain backwards compatibility, but mark it as deprecated.
     - Add `WorkflowDefinition.isAllowedStateTransition` helper for checking allowed transitions.
 - `nflow-rest-api`
-  - Add optional state transition validation for workflow instance updates.
-    - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` when transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
+  - Add optional expected state and state transition validations for workflow instance updates.
+    - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` when expected state does not match the workflow instance state in the database.
+    - Workflow instance update endpoints now take optional `validationMode` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` when transition from expected state to requested new state is not allowed by the workflow definition.
+    - `validationMode` is ignored when `expectedState` is not given.
 
 ## 10.0.2 (2026-05-23)
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/dao/WorkflowInstanceDao.java
@@ -484,7 +484,7 @@ public class WorkflowInstanceDao {
         + executorInfo.getExecutorId();
   }
 
-  public boolean updateNotRunningWorkflowInstance(WorkflowInstance instance) {
+  public boolean updateNotRunningWorkflowInstance(WorkflowInstance instance, Optional<String> expectedState) {
     List<String> vars = new ArrayList<>();
     List<Object> args = new ArrayList<>();
     if (instance.state != null) {
@@ -509,6 +509,10 @@ public class WorkflowInstanceDao {
     }
     String sql = "update nflow_workflow set " + join(vars, ", ") + " where id = ? and executor_id is null";
     args.add(instance.id);
+    if (expectedState.isPresent()) {
+      sql += " and state = ?";
+      args.add(expectedState.get());
+    }
     return jdbc.update(sql, args.toArray()) == 1;
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
@@ -135,7 +135,8 @@ public class WorkflowInstanceService {
    * @param expectedState
    *          Optional expected current state for optimistic state transition check.
    * @param validationMode
-   *          Defines which state transitions are allowed, when expectedState is present.
+  *          Defines which state transitions are allowed, when expectedState is present. Must be
+  *          {@link StateTransitionValidationMode#doNotValidate} when expectedState is not present.
    * @return True if the update was successful, false otherwise.
    */
   @Transactional
@@ -146,6 +147,8 @@ public class WorkflowInstanceService {
     Assert.notNull(action, "Workflow instance action can not be null");
     Assert.notNull(expectedState, "Expected state can not be null");
     Assert.notNull(validationMode, "Validation mode can not be null");
+    Assert.isTrue(expectedState.isPresent() || validationMode == StateTransitionValidationMode.doNotValidate,
+        "Validation mode must be doNotValidate when expected state is not given");
     Assert.notNull(workflowDefinitionService, "workflowDefinitionService can not be null");
     try {
       WorkflowInstance.Builder builder = new WorkflowInstance.Builder(instance);

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
@@ -102,17 +102,20 @@ public class WorkflowInstanceService {
 
   /**
    * Update the workflow instance in the database if it is currently not running, and insert the workflow instance action.
+   * If expectedState is present, update is allowed only when the current state matches it.
    * If the state of the instance is not null, the status of the instance is updated based on the new state.
    * If the state of the instance is null, neither state nor status are updated.
    * @param instance The instance to be updated.
    * @param action The action to be inserted.
+   * @param expectedState Optional expected current state for optimistic state transition check.
    * @return True if the update was successful, false otherwise.
    */
   @Transactional
   @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "NflowNotFoundException message is ok")
-  public boolean updateWorkflowInstance(WorkflowInstance instance, WorkflowInstanceAction action) {
+  public boolean updateWorkflowInstance(WorkflowInstance instance, WorkflowInstanceAction action, Optional<String> expectedState) {
     Assert.notNull(instance, "Workflow instance can not be null");
     Assert.notNull(action, "Workflow instance action can not be null");
+    Assert.notNull(expectedState, "Expected state can not be null");
     Assert.notNull(workflowDefinitionService, "workflowDefinitionService can not be null");
     try {
       WorkflowInstance.Builder builder = new WorkflowInstance.Builder(instance);
@@ -121,10 +124,13 @@ public class WorkflowInstanceService {
       } else {
         String type = workflowInstanceDao.getWorkflowInstanceType(instance.id);
         WorkflowDefinition definition = workflowDefinitionService.getWorkflowDefinition(type);
+        if (!expectedState.map(currentState -> definition.isAllowedStateTransition(currentState, instance.state)).orElse(Boolean.TRUE)) {
+          return false;
+        }
         builder.setStatus(definition.getState(instance.state).getType().getStatus(instance.nextActivation));
       }
       WorkflowInstance updatedInstance = builder.build();
-      boolean updated = workflowInstanceDao.updateNotRunningWorkflowInstance(updatedInstance);
+      boolean updated = workflowInstanceDao.updateNotRunningWorkflowInstance(updatedInstance, expectedState);
       if (updated) {
         String currentState = workflowInstanceDao.getWorkflowInstanceState(updatedInstance.id);
         WorkflowInstanceAction updatedAction = new WorkflowInstanceAction.Builder(action).setState(currentState).build();
@@ -213,4 +219,5 @@ public class WorkflowInstanceService {
         .setParentWorkflowId(workflowInstanceId).build();
     return !listWorkflowInstances(unfinishedChildren).isEmpty();
   }
+
 }

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
@@ -12,8 +12,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import jakarta.inject.Inject;
-
 import org.slf4j.Logger;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
@@ -29,6 +27,7 @@ import io.nflow.engine.workflow.instance.WorkflowInstance;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 import io.nflow.engine.workflow.instance.WorkflowInstanceAction;
 import io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType;
+import jakarta.inject.Inject;
 
 /**
  * Service for managing workflow instances.
@@ -98,6 +97,22 @@ public class WorkflowInstanceService {
       id = workflowInstanceDao.queryWorkflowInstances(query).get(0).id;
     }
     return id;
+  }
+
+  /**
+   * Update the workflow instance in the database if it is currently not running, and insert the workflow instance action.
+   * If the state of the instance is not null, the status of the instance is updated based on the new state.
+   * If the state of the instance is null, neither state nor status are updated.
+   * @param instance The instance to be updated.
+   * @param action The action to be inserted.
+   * @return True if the update was successful, false otherwise.
+   * @deprecated Use {@link #updateWorkflowInstance(WorkflowInstance, WorkflowInstanceAction, Optional)} instead.
+   */
+  @Deprecated
+  @Transactional
+  @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "NflowNotFoundException message is ok")
+  public boolean updateWorkflowInstance(WorkflowInstance instance, WorkflowInstanceAction action) {
+    return updateWorkflowInstance(instance, action, Optional.empty());
   }
 
   /**

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
@@ -110,7 +110,6 @@ public class WorkflowInstanceService {
    */
   @Deprecated
   @Transactional
-  @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "NflowNotFoundException message is ok")
   public boolean updateWorkflowInstance(WorkflowInstance instance, WorkflowInstanceAction action) {
     return updateWorkflowInstance(instance, action, Optional.empty());
   }

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
@@ -21,6 +21,7 @@ import org.springframework.util.Assert;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.nflow.engine.internal.dao.WorkflowInstanceDao;
 import io.nflow.engine.internal.workflow.WorkflowInstancePreProcessor;
+import io.nflow.engine.workflow.definition.StateTransitionValidationMode;
 import io.nflow.engine.workflow.definition.WorkflowDefinition;
 import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
@@ -73,7 +74,8 @@ public class WorkflowInstanceService {
    * @throws EmptyResultDataAccessException if not found
    */
   @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "NflowNotFoundException message is ok")
-  public WorkflowInstance getWorkflowInstance(long id, Set<WorkflowInstanceInclude> includes, Long maxActions, boolean queryArchive) {
+  public WorkflowInstance getWorkflowInstance(long id, Set<WorkflowInstanceInclude> includes, Long maxActions,
+      boolean queryArchive) {
     try {
       return workflowInstanceDao.getWorkflowInstance(id, includes, maxActions, queryArchive);
     } catch (EmptyResultDataAccessException e) {
@@ -93,43 +95,57 @@ public class WorkflowInstanceService {
     WorkflowInstance processedInstance = workflowInstancePreProcessor.process(instance);
     long id = workflowInstanceDao.insertWorkflowInstance(processedInstance);
     if (id == -1 && hasText(instance.externalId)) {
-      QueryWorkflowInstances query = new QueryWorkflowInstances.Builder().addTypes(instance.type).setExternalId(instance.externalId).build();
+      QueryWorkflowInstances query = new QueryWorkflowInstances.Builder().addTypes(instance.type)
+          .setExternalId(instance.externalId).build();
       id = workflowInstanceDao.queryWorkflowInstances(query).get(0).id;
     }
     return id;
   }
 
   /**
-   * Update the workflow instance in the database if it is currently not running, and insert the workflow instance action.
-   * If the state of the instance is not null, the status of the instance is updated based on the new state.
-   * If the state of the instance is null, neither state nor status are updated.
-   * @param instance The instance to be updated.
-   * @param action The action to be inserted.
+   * Update the workflow instance in the database if it is currently not running, and insert the workflow instance action. If the
+   * state of the instance is not null, the status of the instance is updated based on the new state. If the state of the instance
+   * is null, neither state nor status are updated.
+   *
+   * @param instance
+   *          The instance to be updated.
+   * @param action
+   *          The action to be inserted.
    * @return True if the update was successful, false otherwise.
-   * @deprecated Use {@link #updateWorkflowInstance(WorkflowInstance, WorkflowInstanceAction, Optional)} instead.
+   * @deprecated Use
+   *             {@link #updateWorkflowInstance(WorkflowInstance, WorkflowInstanceAction, Optional, StateTransitionValidationMode)}
+   *             instead.
    */
   @Deprecated
   @Transactional
   public boolean updateWorkflowInstance(WorkflowInstance instance, WorkflowInstanceAction action) {
-    return updateWorkflowInstance(instance, action, Optional.empty());
+    return updateWorkflowInstance(instance, action, Optional.empty(), StateTransitionValidationMode.doNotValidate);
   }
 
   /**
-   * Update the workflow instance in the database if it is currently not running, and insert the workflow instance action.
-   * If expectedState is present, update is allowed only when the current state matches it.
-   * If the state of the instance is not null, the status of the instance is updated based on the new state.
-   * If the state of the instance is null, neither state nor status are updated.
-   * @param instance The instance to be updated.
-   * @param action The action to be inserted.
-   * @param expectedState Optional expected current state for optimistic state transition check.
+   * Update the workflow instance in the database if it is currently not running, and insert the workflow instance action. If
+   * expectedState is present, update is allowed only when the current state matches it. If the state of the instance is not null,
+   * the status of the instance is updated based on the new state. If the state of the instance is null, neither state nor status
+   * are updated.
+   *
+   * @param instance
+   *          The instance to be updated.
+   * @param action
+   *          The action to be inserted.
+   * @param expectedState
+   *          Optional expected current state for optimistic state transition check.
+   * @param validationMode
+   *          Defines which state transitions are allowed, when expectedState is present.
    * @return True if the update was successful, false otherwise.
    */
   @Transactional
   @SuppressFBWarnings(value = "WEM_WEAK_EXCEPTION_MESSAGING", justification = "NflowNotFoundException message is ok")
-  public boolean updateWorkflowInstance(WorkflowInstance instance, WorkflowInstanceAction action, Optional<String> expectedState) {
+  public boolean updateWorkflowInstance(WorkflowInstance instance, WorkflowInstanceAction action, Optional<String> expectedState,
+      StateTransitionValidationMode validationMode) {
     Assert.notNull(instance, "Workflow instance can not be null");
     Assert.notNull(action, "Workflow instance action can not be null");
     Assert.notNull(expectedState, "Expected state can not be null");
+    Assert.notNull(validationMode, "Validation mode can not be null");
     Assert.notNull(workflowDefinitionService, "workflowDefinitionService can not be null");
     try {
       WorkflowInstance.Builder builder = new WorkflowInstance.Builder(instance);
@@ -138,7 +154,8 @@ public class WorkflowInstanceService {
       } else {
         String type = workflowInstanceDao.getWorkflowInstanceType(instance.id);
         WorkflowDefinition definition = workflowDefinitionService.getWorkflowDefinition(type);
-        if (!expectedState.map(currentState -> definition.isAllowedStateTransition(currentState, instance.state)).orElse(Boolean.TRUE)) {
+        if (!expectedState.map(currentState -> definition.isAllowedStateTransition(currentState, instance.state, validationMode))
+            .orElse(Boolean.TRUE)) {
           return false;
         }
         builder.setStatus(definition.getState(instance.state).getType().getStatus(instance.nextActivation));
@@ -233,5 +250,4 @@ public class WorkflowInstanceService {
         .setParentWorkflowId(workflowInstanceId).build();
     return !listWorkflowInstances(unfinishedChildren).isEmpty();
   }
-
 }

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateTransitionValidationMode.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateTransitionValidationMode.java
@@ -1,0 +1,27 @@
+package io.nflow.engine.workflow.definition;
+
+/**
+ * Defines which workflow state transitions are accepted when validating a transition.
+ */
+public enum StateTransitionValidationMode {
+
+  /**
+   * Allow only normal transitions configured in workflow definition state transitions.
+   */
+  allowNormal,
+
+  /**
+   * Allow only failure transition configured in the workflow definition.
+   */
+  allowFailure,
+
+  /**
+   * Allow both normal and failure transitions configured in workflow definition.
+   */
+  allowNormalAndFailure,
+
+  /**
+   * Disable transition validation and allow all transitions.
+   */
+  doNotValidate
+}

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
@@ -2,6 +2,7 @@ package io.nflow.engine.workflow.definition;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
+import static java.util.Optional.ofNullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -118,7 +119,7 @@ public abstract class WorkflowDefinition extends ModelObject {
    *          The states to be registered for the workflow. If null, the states will be scanned.
    */
   protected WorkflowDefinition(String type, WorkflowState initialState, WorkflowState errorState, WorkflowSettings settings,
-                               Map<String, WorkflowStateMethod> stateMethods, Collection<WorkflowState> states) {
+      Map<String, WorkflowStateMethod> stateMethods, Collection<WorkflowState> states) {
     this(type, initialState, errorState, settings, stateMethods, states, true);
   }
 
@@ -407,6 +408,21 @@ public abstract class WorkflowDefinition extends ModelObject {
    */
   public boolean isStartState(String state) {
     return getState(state).getType() == WorkflowStateType.start;
+  }
+
+  /**
+   * Return true if state transition from currentState to newState is allowed by workflow definition.
+   *
+   * @param currentState
+   *          Current workflow state name.
+   * @param newState
+   *          New workflow state name.
+   * @return True if transition is allowed, false otherwise.
+   */
+  public boolean isAllowedStateTransition(String currentState, String newState) {
+    return ofNullable(allowedTransitions.get(currentState))
+        .map(nextStates -> nextStates.contains(newState))
+        .orElse(Boolean.FALSE);
   }
 
   /**

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/WorkflowDefinition.java
@@ -417,11 +417,29 @@ public abstract class WorkflowDefinition extends ModelObject {
    *          Current workflow state name.
    * @param newState
    *          New workflow state name.
+   * @param validationMode
+   *          Defines which transitions are allowed.
    * @return True if transition is allowed, false otherwise.
    */
-  public boolean isAllowedStateTransition(String currentState, String newState) {
-    return ofNullable(allowedTransitions.get(currentState))
+  public boolean isAllowedStateTransition(String currentState, String newState, StateTransitionValidationMode validationMode) {
+    return switch (validationMode) {
+    case allowNormal -> isNormalTransitionAllowed(currentState, newState);
+    case allowFailure -> isFailureTransitionAllowed(currentState, newState);
+    case allowNormalAndFailure -> isNormalTransitionAllowed(currentState, newState)
+        || isFailureTransitionAllowed(currentState, newState);
+    case doNotValidate -> true;
+    };
+  }
+
+  private Boolean isNormalTransitionAllowed(String currentState, String newState) {
+    return ofNullable(this.allowedTransitions.get(currentState))
         .map(nextStates -> nextStates.contains(newState))
+        .orElse(Boolean.FALSE);
+  }
+
+  private Boolean isFailureTransitionAllowed(String currentState, String newState) {
+    return ofNullable(this.failureTransitions.get(currentState))
+      .map(failureState -> failureState.name().equals(newState))
         .orElse(Boolean.FALSE);
   }
 

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/StatisticsDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/StatisticsDaoTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.joda.time.DateTime.now;
 
 import java.util.Map;
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
@@ -74,7 +75,7 @@ public class StatisticsDaoTest extends BaseDaoTest {
     assertThat(stateStats.get(created.name()).allInstances, is(1L));
 
     WorkflowInstance i2 = new WorkflowInstance.Builder().setId(id).setNextActivation(now().minusDays(1)).build();
-    instanceDao.updateNotRunningWorkflowInstance(i2);
+    instanceDao.updateNotRunningWorkflowInstance(i2, Optional.empty());
 
     stats = statisticsDao.getWorkflowDefinitionStatistics(i1.type, null, null, null, null);
     stateStats = stats.get(TestState.BEGIN.name());

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/StatisticsDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/StatisticsDaoTest.java
@@ -13,8 +13,6 @@ import static org.joda.time.DateTime.now;
 import java.util.Map;
 import java.util.Optional;
 
-import jakarta.inject.Inject;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +21,7 @@ import io.nflow.engine.workflow.definition.WorkflowDefinitionStatistics;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
 import io.nflow.engine.workflow.statistics.Statistics;
 import io.nflow.engine.workflow.statistics.Statistics.QueueStatistics;
+import jakarta.inject.Inject;
 
 public class StatisticsDaoTest extends BaseDaoTest {
 
@@ -75,7 +74,7 @@ public class StatisticsDaoTest extends BaseDaoTest {
     assertThat(stateStats.get(created.name()).allInstances, is(1L));
 
     WorkflowInstance i2 = new WorkflowInstance.Builder().setId(id).setNextActivation(now().minusDays(1)).build();
-    instanceDao.updateNotRunningWorkflowInstance(i2, Optional.empty());
+    instanceDao.updateNotRunningWorkflowInstance(i2, Optional.of(i1.state));
 
     stats = statisticsDao.getWorkflowDefinitionStatistics(i1.type, null, null, null, null);
     stateStats = stats.get(TestState.BEGIN.name());

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -415,7 +415,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     long id = dao.insertWorkflowInstance(instance);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setNextActivation(null).setStatus(manual)
         .setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.of(instance.state));
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -435,7 +435,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     long id = dao.insertWorkflowInstance(instance);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setState("manualState")
         .setNextActivation(null).setStatus(null).setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.of(instance.state));
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -456,7 +456,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     final DateTime tomorrow = now().plusDays(1);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setNextActivation(tomorrow)
         .setStatus(null).setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.of(instance.state));
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -476,7 +476,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     long id = dao.insertWorkflowInstance(instance);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setBusinessKey("modifiedKey")
         .setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.of(instance.state));
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -498,7 +498,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     final DateTime tomorrow = now().plusDays(1);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setState("manualState")
         .setNextActivation(tomorrow).setStatus(manual).build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.of(instance.state));
     assertThat(updated, is(false));
   }
 

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/dao/WorkflowInstanceDaoTest.java
@@ -415,7 +415,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     long id = dao.insertWorkflowInstance(instance);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setNextActivation(null).setStatus(manual)
         .setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance);
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -435,7 +435,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     long id = dao.insertWorkflowInstance(instance);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setState("manualState")
         .setNextActivation(null).setStatus(null).setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance);
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -456,7 +456,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     final DateTime tomorrow = now().plusDays(1);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setNextActivation(tomorrow)
         .setStatus(null).setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance);
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -476,7 +476,7 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     long id = dao.insertWorkflowInstance(instance);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setBusinessKey("modifiedKey")
         .setStateText("modified").build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance);
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
     assertThat(updated, is(true));
     jdbc.query("select * from nflow_workflow where id = " + id, new RowCallbackHandler() {
       @Override
@@ -498,8 +498,21 @@ public class WorkflowInstanceDaoTest extends BaseDaoTest {
     final DateTime tomorrow = now().plusDays(1);
     WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setState("manualState")
         .setNextActivation(tomorrow).setStatus(manual).build();
-    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance);
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.empty());
     assertThat(updated, is(false));
+  }
+
+  @Test
+  public void updateNotRunningWorkflowInstanceDoesNotUpdateWhenExpectedStateDoesNotMatch() {
+    WorkflowInstance instance = constructWorkflowInstanceBuilder().build();
+    long id = dao.insertWorkflowInstance(instance);
+    WorkflowInstance modifiedInstance = new WorkflowInstance.Builder(instance).setId(id).setState("manualState").build();
+
+    boolean updated = dao.updateNotRunningWorkflowInstance(modifiedInstance, Optional.of("otherState"));
+
+    assertThat(updated, is(false));
+    WorkflowInstance after = dao.getWorkflowInstance(id, emptySet(), null, false);
+    assertThat(after.state, is(instance.state));
   }
 
   @Test

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
@@ -195,6 +195,17 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
   }
 
   @Test
+  public void updateWorkflowInstanceThrowsExceptionWhenExpectedStateIsMissingAndValidationModeIsNotDoNotValidate() {
+    WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
+
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+        () -> service.updateWorkflowInstance(i, a, Optional.empty(), allowNormal));
+
+    assertThat(thrown.getMessage(), is("Validation mode must be doNotValidate when expected state is not given"));
+  }
+
+  @Test
   public void updateWorkflowInstanceWorksWhenStateIsNull() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setState((String) null).setId(42).build();
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
@@ -217,7 +228,7 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(false);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
 
-    boolean result = service.updateWorkflowInstance(i, a, Optional.empty(), allowNormal);
+    boolean result = service.updateWorkflowInstance(i, a, Optional.empty(), doNotValidate);
 
     assertThat(result, is(false));
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), eq(Optional.empty()));

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
@@ -114,9 +114,9 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
-    
+
     assertThat(service.updateWorkflowInstance(i, a, Optional.empty()), is(true));
-    
+
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.empty()));
     assertThat(stored.getValue().status, is(inProgress));
     verify(workflowInstanceDao).insertWorkflowInstanceAction(stored2.capture(), storedAction.capture());
@@ -156,7 +156,7 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(false);
-    
+
     assertThat(service.updateWorkflowInstance(i, a, Optional.of("begin")), is(false));
 
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), eq(Optional.of("begin")));
@@ -178,8 +178,8 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
     when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
-    assertThat(service.updateWorkflowInstance(i, a, Optional.empty()), is(true));
-    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.empty()));
+    assertThat(service.updateWorkflowInstance(i, a, Optional.of("currentState")), is(true));
+    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.of("currentState")));
     assertThat(stored.getValue().status, is(nullValue()));
     verify(workflowInstanceDao).insertWorkflowInstanceAction(stored2.capture(), storedAction.capture());
     assertThat(storedAction.getValue().state, is("currentState"));

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
@@ -1,5 +1,7 @@
 package io.nflow.engine.service;
 
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.allowNormal;
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.doNotValidate;
 import static io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus.created;
 import static io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus.inProgress;
 import static io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
@@ -23,10 +25,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -43,6 +47,7 @@ import org.mockito.Mockito;
 import io.nflow.engine.internal.dao.WorkflowInstanceDao;
 import io.nflow.engine.internal.executor.BaseNflowTest;
 import io.nflow.engine.internal.workflow.WorkflowInstancePreProcessor;
+import io.nflow.engine.workflow.definition.StateTransitionValidationMode;
 import io.nflow.engine.workflow.definition.WorkflowDefinition;
 import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
@@ -86,7 +91,10 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     @SuppressWarnings("unchecked")
     Set<WorkflowInstanceInclude> includes = Mockito.mock(Set.class);
     when(workflowInstanceDao.getWorkflowInstance(42, includes, 10L, false)).thenReturn(instance);
-    assertEquals(instance, service.getWorkflowInstance(42, includes, 10L));
+
+    WorkflowInstance result = service.getWorkflowInstance(42, includes, 10L);
+
+    assertEquals(instance, result);
   }
 
   @Test
@@ -94,7 +102,10 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setStatus(created).setExternalId("123").build();
     when(workflowInstancePreProcessor.process(i)).thenReturn(i);
     when(workflowInstanceDao.insertWorkflowInstance(stored.capture())).thenReturn(42L);
-    assertThat(service.insertWorkflowInstance(i), is(42L));
+
+    long result = service.insertWorkflowInstance(i);
+
+    assertThat(result, is(42L));
     assertThat(stored.getValue().externalId, is("123"));
     assertThat(stored.getValue().status, is(created));
   }
@@ -115,7 +126,9 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
 
-    assertThat(service.updateWorkflowInstance(i, a, Optional.empty()), is(true));
+    boolean result = service.updateWorkflowInstance(i, a, Optional.empty(), doNotValidate);
+
+    assertThat(result, is(true));
 
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.empty()));
     assertThat(stored.getValue().status, is(inProgress));
@@ -127,11 +140,14 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
   public void updateWorkflowInstanceWorksWhenExpectedStateMatches() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).setState("done").build();
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
+    mockIsAllowedStateTransition(true);
     when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
 
-    assertThat(service.updateWorkflowInstance(i, a, Optional.of("begin")), is(true));
+    boolean result = service.updateWorkflowInstance(i, a, Optional.of("begin"), allowNormal);
+
+    assertThat(result, is(true));
 
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.of("begin")));
     assertThat(stored.getValue().status, is(inProgress));
@@ -143,9 +159,12 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
   public void updateWorkflowInstanceReturnsFalseWhenExpectedStateTransitionIsNotAllowed() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
+    mockIsAllowedStateTransition(false);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
 
-    assertThat(service.updateWorkflowInstance(i, a, Optional.of("begin")), is(false));
+    boolean result = service.updateWorkflowInstance(i, a, Optional.of("begin"), allowNormal);
+
+    assertThat(result, is(false));
     verify(workflowInstanceDao, never()).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any());
     verify(workflowInstanceDao, never()).insertWorkflowInstanceAction(any(WorkflowInstance.class), any(WorkflowInstanceAction.class));
   }
@@ -154,10 +173,13 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
   public void updateWorkflowInstanceFailsWhenExpectedStateDoesNotMatch() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).setState("done").build();
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
+    mockIsAllowedStateTransition(true);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(false);
 
-    assertThat(service.updateWorkflowInstance(i, a, Optional.of("begin")), is(false));
+    boolean result = service.updateWorkflowInstance(i, a, Optional.of("begin"), allowNormal);
+
+    assertThat(result, is(false));
 
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), eq(Optional.of("begin")));
     verify(workflowInstanceDao, never()).insertWorkflowInstanceAction(any(WorkflowInstance.class), any(WorkflowInstanceAction.class));
@@ -168,7 +190,7 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
     WorkflowInstanceAction a = null;
     IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-      () -> service.updateWorkflowInstance(i, a, Optional.empty()));
+        () -> service.updateWorkflowInstance(i, a, Optional.empty(), doNotValidate));
     assertThat(thrown.getMessage(), is("Workflow instance action can not be null"));
   }
 
@@ -178,7 +200,10 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
     when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
-    assertThat(service.updateWorkflowInstance(i, a, Optional.of("currentState")), is(true));
+
+    boolean result = service.updateWorkflowInstance(i, a, Optional.of("currentState"), allowNormal);
+
+    assertThat(result, is(true));
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.of("currentState")));
     assertThat(stored.getValue().status, is(nullValue()));
     verify(workflowInstanceDao).insertWorkflowInstanceAction(stored2.capture(), storedAction.capture());
@@ -191,7 +216,10 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).build();
     when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(false);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
-    assertThat(service.updateWorkflowInstance(i, a, Optional.empty()), is(false));
+
+    boolean result = service.updateWorkflowInstance(i, a, Optional.empty(), allowNormal);
+
+    assertThat(result, is(false));
     verify(workflowInstanceDao).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), eq(Optional.empty()));
     verify(workflowInstanceDao, never()).insertWorkflowInstanceAction(any(WorkflowInstance.class),
         any(WorkflowInstanceAction.class));
@@ -209,14 +237,19 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     List<WorkflowInstance> result = asList(constructWorkflowInstanceBuilder().build());
     QueryWorkflowInstances query = mock(QueryWorkflowInstances.class);
     when(workflowInstanceDao.queryWorkflowInstances(query)).thenReturn(result);
-    assertEquals(result, service.listWorkflowInstances(query));
+
+    Collection<WorkflowInstance> listedInstances = service.listWorkflowInstances(query);
+
+    assertEquals(result, listedInstances);
   }
 
   @Test
   public void getSignalWorks() {
     when(workflowInstanceDao.getSignal(99)).thenReturn(Optional.of(42));
 
-    assertThat(service.getSignal(99), is(Optional.of(42)));
+    Optional<Integer> signal = service.getSignal(99);
+
+    assertThat(signal, is(Optional.of(42)));
   }
 
   @Test
@@ -261,7 +294,9 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     List<WorkflowInstance> result = emptyList();
     when(workflowInstanceDao.queryWorkflowInstances(queryCapture.capture())).thenReturn(result);
 
-    assertFalse(service.hasUnfinishedChildWorkflows(42));
+    boolean hasUnfinishedChildWorkflows = service.hasUnfinishedChildWorkflows(42);
+
+    assertFalse(hasUnfinishedChildWorkflows);
     QueryWorkflowInstances query = queryCapture.getValue();
     assertThat(query.parentWorkflowId, is(42L));
     EnumSet.complementOf(EnumSet.of(WorkflowInstanceStatus.finished)).stream()
@@ -275,11 +310,19 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     List<WorkflowInstance> result = asList(unfinished);
     when(workflowInstanceDao.queryWorkflowInstances(queryCapture.capture())).thenReturn(result);
 
-    assertTrue(service.hasUnfinishedChildWorkflows(42));
+    boolean hasUnfinishedChildWorkflows = service.hasUnfinishedChildWorkflows(42);
+
+    assertTrue(hasUnfinishedChildWorkflows);
     QueryWorkflowInstances query = queryCapture.getValue();
     assertThat(query.parentWorkflowId, is(42L));
     EnumSet.complementOf(EnumSet.of(WorkflowInstanceStatus.finished)).stream()
         .forEach(status -> assertTrue(query.statuses.contains(status)));
     assertFalse(query.statuses.contains(WorkflowInstanceStatus.finished));
+  }
+
+  private void mockIsAllowedStateTransition(boolean allowed) {
+    WorkflowDefinition definition = spy(new DummyTestWorkflow());
+    doReturn(allowed).when(definition).isAllowedStateTransition(anyString(), anyString(), any(StateTransitionValidationMode.class));
+    doReturn(definition).when(workflowDefinitions).getWorkflowDefinition("dummy");
   }
 }

--- a/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/service/WorkflowInstanceServiceTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -111,20 +112,63 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
     when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
-    when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class))).thenReturn(true);
+    when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
-    assertThat(service.updateWorkflowInstance(i, a), is(true));
-    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture());
+    
+    assertThat(service.updateWorkflowInstance(i, a, Optional.empty()), is(true));
+    
+    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.empty()));
     assertThat(stored.getValue().status, is(inProgress));
     verify(workflowInstanceDao).insertWorkflowInstanceAction(stored2.capture(), storedAction.capture());
     assertThat(storedAction.getValue().state, is("currentState"));
   }
 
   @Test
+  public void updateWorkflowInstanceWorksWhenExpectedStateMatches() {
+    WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).setState("done").build();
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
+    when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
+    when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
+    when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
+
+    assertThat(service.updateWorkflowInstance(i, a, Optional.of("begin")), is(true));
+
+    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.of("begin")));
+    assertThat(stored.getValue().status, is(inProgress));
+    verify(workflowInstanceDao).insertWorkflowInstanceAction(stored2.capture(), storedAction.capture());
+    assertThat(storedAction.getValue().state, is("currentState"));
+  }
+
+  @Test
+  public void updateWorkflowInstanceReturnsFalseWhenExpectedStateTransitionIsNotAllowed() {
+    WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
+    when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
+
+    assertThat(service.updateWorkflowInstance(i, a, Optional.of("begin")), is(false));
+    verify(workflowInstanceDao, never()).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any());
+    verify(workflowInstanceDao, never()).insertWorkflowInstanceAction(any(WorkflowInstance.class), any(WorkflowInstanceAction.class));
+  }
+
+  @Test
+  public void updateWorkflowInstanceFailsWhenExpectedStateDoesNotMatch() {
+    WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).setState("done").build();
+    WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
+    when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
+    when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(false);
+    
+    assertThat(service.updateWorkflowInstance(i, a, Optional.of("begin")), is(false));
+
+    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), eq(Optional.of("begin")));
+    verify(workflowInstanceDao, never()).insertWorkflowInstanceAction(any(WorkflowInstance.class), any(WorkflowInstanceAction.class));
+  }
+
+  @Test
   public void updateWorkflowInstanceThrowsExceptionWhenActionIsNull() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
     WorkflowInstanceAction a = null;
-    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> service.updateWorkflowInstance(i, a));
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+      () -> service.updateWorkflowInstance(i, a, Optional.empty()));
     assertThat(thrown.getMessage(), is("Workflow instance action can not be null"));
   }
 
@@ -133,9 +177,9 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setState((String) null).setId(42).build();
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).setWorkflowInstanceId(i.id).build();
     when(workflowInstanceDao.getWorkflowInstanceState(i.id)).thenReturn("currentState");
-    when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class))).thenReturn(true);
-    assertThat(service.updateWorkflowInstance(i, a), is(true));
-    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture());
+    when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(true);
+    assertThat(service.updateWorkflowInstance(i, a, Optional.empty()), is(true));
+    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(stored.capture(), eq(Optional.empty()));
     assertThat(stored.getValue().status, is(nullValue()));
     verify(workflowInstanceDao).insertWorkflowInstanceAction(stored2.capture(), storedAction.capture());
     assertThat(storedAction.getValue().state, is("currentState"));
@@ -145,9 +189,10 @@ public class WorkflowInstanceServiceTest extends BaseNflowTest {
   public void updateRunningWorkflowInstanceFails() {
     WorkflowInstance i = constructWorkflowInstanceBuilder().setId(42).build();
     WorkflowInstanceAction a = new WorkflowInstanceAction.Builder().setType(externalChange).build();
-    when(workflowInstanceDao.updateNotRunningWorkflowInstance(i)).thenReturn(false);
+    when(workflowInstanceDao.updateNotRunningWorkflowInstance(any(WorkflowInstance.class), any())).thenReturn(false);
     when(workflowInstanceDao.getWorkflowInstanceType(42)).thenReturn(i.type);
-    assertThat(service.updateWorkflowInstance(i, a), is(false));
+    assertThat(service.updateWorkflowInstance(i, a, Optional.empty()), is(false));
+    verify(workflowInstanceDao).updateNotRunningWorkflowInstance(any(WorkflowInstance.class), eq(Optional.empty()));
     verify(workflowInstanceDao, never()).insertWorkflowInstanceAction(any(WorkflowInstance.class),
         any(WorkflowInstanceAction.class));
   }

--- a/nflow-engine/src/test/java/io/nflow/engine/workflow/definition/WorkflowDefinitionTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/workflow/definition/WorkflowDefinitionTest.java
@@ -13,6 +13,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -99,5 +101,20 @@ public class WorkflowDefinitionTest {
     assertThat(workflow.isStartState(STATE_2.name()), equalTo(false));
     assertThat(workflow.isStartState(ERROR.name()), equalTo(false));
     assertThat(workflow.isStartState(DONE.name()), equalTo(false));
+  }
+
+  @Test
+  public void isAllowedStateTransitionReturnsTrueForPermittedTransition() {
+    WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
+
+    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), DONE.name()));
+  }
+
+  @Test
+  public void isAllowedStateTransitionReturnsFalseForNonPermittedTransition() {
+    WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
+
+    assertFalse(workflow.isAllowedStateTransition(BEGIN.name(), POLL.name()));
+    assertFalse(workflow.isAllowedStateTransition("unknown", DONE.name()));
   }
 }

--- a/nflow-engine/src/test/java/io/nflow/engine/workflow/definition/WorkflowDefinitionTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/workflow/definition/WorkflowDefinitionTest.java
@@ -1,6 +1,10 @@
 package io.nflow.engine.workflow.definition;
 
 import static io.nflow.engine.workflow.definition.TestDefinition.START_1;
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.allowFailure;
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.allowNormal;
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.allowNormalAndFailure;
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.doNotValidate;
 import static io.nflow.engine.workflow.definition.TestDefinitionWithStateTypes.STATE_1;
 import static io.nflow.engine.workflow.definition.TestDefinitionWithStateTypes.STATE_2;
 import static io.nflow.engine.workflow.definition.TestState.BEGIN;
@@ -107,14 +111,48 @@ public class WorkflowDefinitionTest {
   public void isAllowedStateTransitionReturnsTrueForPermittedTransition() {
     WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
 
-    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), DONE.name()));
+    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), DONE.name(), allowNormal));
   }
 
   @Test
   public void isAllowedStateTransitionReturnsFalseForNonPermittedTransition() {
     WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
 
-    assertFalse(workflow.isAllowedStateTransition(BEGIN.name(), POLL.name()));
-    assertFalse(workflow.isAllowedStateTransition("unknown", DONE.name()));
+    assertFalse(workflow.isAllowedStateTransition(BEGIN.name(), POLL.name(), allowNormal));
+    assertFalse(workflow.isAllowedStateTransition("unknown", DONE.name(), allowNormal));
+  }
+
+  @Test
+  public void isAllowedStateTransitionWorksForAllowFailureMode() {
+    WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
+
+    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), ERROR.name(), allowFailure));
+    assertFalse(workflow.isAllowedStateTransition(BEGIN.name(), DONE.name(), allowFailure));
+    assertFalse(workflow.isAllowedStateTransition("unknown", ERROR.name(), allowFailure));
+  }
+
+  @Test
+  public void isAllowedStateTransitionWorksForAllowFailureModeWithNonInternedString() {
+    WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
+
+    String newState = new String(ERROR.name());
+    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), newState, allowFailure));
+  }
+
+  @Test
+  public void isAllowedStateTransitionWorksForAllowNormalAndFailureMode() {
+    WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
+
+    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), DONE.name(), allowNormalAndFailure));
+    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), ERROR.name(), allowNormalAndFailure));
+    assertFalse(workflow.isAllowedStateTransition(BEGIN.name(), POLL.name(), allowNormalAndFailure));
+  }
+
+  @Test
+  public void isAllowedStateTransitionWorksForDoNotValidateMode() {
+    WorkflowDefinition workflow = new TestDefinitionWithStateTypes("y", BEGIN);
+
+    assertTrue(workflow.isAllowedStateTransition(BEGIN.name(), POLL.name(), doNotValidate));
+    assertTrue(workflow.isAllowedStateTransition("unknown", "nonexistent", doNotValidate));
   }
 }

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -101,7 +102,7 @@ public abstract class ResourceBase {
 
   public boolean updateWorkflowInstance(long id, UpdateWorkflowInstanceRequest req,
       WorkflowInstanceFactory workflowInstanceFactory, WorkflowInstanceService workflowInstances,
-      WorkflowInstanceDao workflowInstanceDao) {
+      WorkflowInstanceDao workflowInstanceDao, Optional<String> expectedState) {
     WorkflowInstance.Builder builder = workflowInstanceFactory.newWorkflowInstanceBuilder().setId(id)
         .setNextActivation(req.nextActivationTime);
     String msg = defaultIfBlank(req.actionDescription, "");
@@ -143,7 +144,7 @@ public abstract class ResourceBase {
         .setStateText(trimToNull(msg))
         .setExecutionEnd(now())
         .build();
-    return workflowInstances.updateWorkflowInstance(instance, action);
+    return workflowInstances.updateWorkflowInstance(instance, action, expectedState);
   }
 
   public Stream<ListWorkflowInstanceResponse> listWorkflowInstances(Set<Long> ids, Set<String> types, Long parentWorkflowId,

--- a/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
+++ b/nflow-rest-api-common/src/main/java/io/nflow/rest/v1/ResourceBase.java
@@ -9,6 +9,7 @@ import static java.lang.Boolean.parseBoolean;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.util.Optional.ofNullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ import io.nflow.engine.service.NflowNotFoundException;
 import io.nflow.engine.service.WorkflowDefinitionService;
 import io.nflow.engine.service.WorkflowInstanceInclude;
 import io.nflow.engine.service.WorkflowInstanceService;
+import io.nflow.engine.workflow.definition.StateTransitionValidationMode;
 import io.nflow.engine.workflow.definition.WorkflowDefinition;
 import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
@@ -100,9 +102,10 @@ public abstract class ResourceBase {
     return response;
   }
 
-  public boolean updateWorkflowInstance(long id, UpdateWorkflowInstanceRequest req,
+    public boolean updateWorkflowInstance(long id, UpdateWorkflowInstanceRequest req,
       WorkflowInstanceFactory workflowInstanceFactory, WorkflowInstanceService workflowInstances,
-      WorkflowInstanceDao workflowInstanceDao, Optional<String> expectedState) {
+      WorkflowInstanceDao workflowInstanceDao, String expectedState,
+      StateTransitionValidationMode validationMode) {
     WorkflowInstance.Builder builder = workflowInstanceFactory.newWorkflowInstanceBuilder().setId(id)
         .setNextActivation(req.nextActivationTime);
     String msg = defaultIfBlank(req.actionDescription, "");
@@ -144,7 +147,10 @@ public abstract class ResourceBase {
         .setStateText(trimToNull(msg))
         .setExecutionEnd(now())
         .build();
-    return workflowInstances.updateWorkflowInstance(instance, action, expectedState);
+    Optional<String> normalizedExpectedState = ofNullable(trimToNull(expectedState));
+    StateTransitionValidationMode resolvedValidationMode = ofNullable(validationMode)
+      .orElse(StateTransitionValidationMode.doNotValidate);
+    return workflowInstances.updateWorkflowInstance(instance, action, normalizedExpectedState, resolvedValidationMode);
   }
 
   public Stream<ListWorkflowInstanceResponse> listWorkflowInstances(Set<Long> ids, Set<String> types, Long parentWorkflowId,

--- a/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
+++ b/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
@@ -120,10 +120,12 @@ public class WorkflowInstanceResource extends JaxRsResource {
           description = "If instance could not be updated, for example when state variable value was too long"),
       @ApiResponse(responseCode = "409", description = "If workflow was executing and no update was done") })
   public Response updateWorkflowInstance(@Parameter(description = "Internal id for workflow instance") @PathParam("id") long id,
+      @QueryParam("expectedState") @Parameter(description = "Expected current state of workflow instance") String expectedState,
       @Valid @RequestBody(description = "Submitted workflow instance information",
           required = true) UpdateWorkflowInstanceRequest req) {
     return handleExceptions(() -> {
-      boolean updated = super.updateWorkflowInstance(id, req, workflowInstanceFactory, workflowInstances, workflowInstanceDao);
+      boolean updated = super.updateWorkflowInstance(id, req, workflowInstanceFactory, workflowInstances, workflowInstanceDao,
+          ofNullable(expectedState));
       return (updated ? noContent() : status(CONFLICT));
     });
   }

--- a/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
+++ b/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
@@ -123,7 +123,7 @@ public class WorkflowInstanceResource extends JaxRsResource {
   public Response updateWorkflowInstance(@Parameter(description = "Internal id for workflow instance") @PathParam("id") long id,
       @QueryParam("expectedState") @Parameter(description = "Expected current state of workflow instance") String expectedState,
       @QueryParam("validationMode") @Parameter(
-          description = "Validation mode for state transition check, ignored when expectedState is not given") StateTransitionValidationMode validationMode,
+          description = "Validation mode for state transition check; must be doNotValidate when expectedState is not given") StateTransitionValidationMode validationMode,
       @Valid @RequestBody(description = "Submitted workflow instance information",
           required = true) UpdateWorkflowInstanceRequest req) {
     return handleExceptions(() -> {

--- a/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
+++ b/nflow-rest-api-jax-rs/src/main/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResource.java
@@ -2,7 +2,6 @@ package io.nflow.rest.v1.jaxrs;
 
 import static io.nflow.rest.v1.ResourcePaths.NFLOW_WORKFLOW_INSTANCE_PATH;
 import static io.nflow.rest.v1.ResourcePaths.NFLOW_WORKFLOW_INSTANCE_TAG;
-import static java.util.Optional.ofNullable;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.WILDCARD;
 import static jakarta.ws.rs.core.Response.created;
@@ -10,6 +9,7 @@ import static jakarta.ws.rs.core.Response.noContent;
 import static jakarta.ws.rs.core.Response.ok;
 import static jakarta.ws.rs.core.Response.status;
 import static jakarta.ws.rs.core.Response.Status.CONFLICT;
+import static java.util.Optional.ofNullable;
 
 import java.net.URI;
 import java.util.Collections;
@@ -17,23 +17,12 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.inject.Inject;
-import jakarta.validation.Valid;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.OPTIONS;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Response;
-
 import org.springframework.stereotype.Component;
 
 import io.nflow.engine.internal.dao.WorkflowInstanceDao;
 import io.nflow.engine.service.WorkflowInstanceInclude;
 import io.nflow.engine.service.WorkflowInstanceService;
+import io.nflow.engine.workflow.definition.StateTransitionValidationMode;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 import io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType;
@@ -60,6 +49,17 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
 
 @Path(NFLOW_WORKFLOW_INSTANCE_PATH)
 @Consumes(APPLICATION_JSON)
@@ -118,14 +118,17 @@ public class WorkflowInstanceResource extends JaxRsResource {
   @ApiResponses({ @ApiResponse(responseCode = "204", description = "If update was successful"),
       @ApiResponse(responseCode = "400",
           description = "If instance could not be updated, for example when state variable value was too long"),
-      @ApiResponse(responseCode = "409", description = "If workflow was executing and no update was done") })
+      @ApiResponse(responseCode = "409",
+          description = "If no update was done, for example because workflow was executing, expected state did not match, or requested state transition was not allowed") })
   public Response updateWorkflowInstance(@Parameter(description = "Internal id for workflow instance") @PathParam("id") long id,
       @QueryParam("expectedState") @Parameter(description = "Expected current state of workflow instance") String expectedState,
+      @QueryParam("validationMode") @Parameter(
+          description = "Validation mode for state transition check, ignored when expectedState is not given") StateTransitionValidationMode validationMode,
       @Valid @RequestBody(description = "Submitted workflow instance information",
           required = true) UpdateWorkflowInstanceRequest req) {
     return handleExceptions(() -> {
       boolean updated = super.updateWorkflowInstance(id, req, workflowInstanceFactory, workflowInstances, workflowInstanceDao,
-          ofNullable(expectedState));
+          expectedState, validationMode);
       return (updated ? noContent() : status(CONFLICT));
     });
   }

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
@@ -116,8 +116,9 @@ public class WorkflowInstanceResourceTest {
   @Test
   public void whenUpdatingWithoutParametersNothingHappens() {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
-    verify(workflowInstances, never()).updateWorkflowInstance(any(WorkflowInstance.class), any(WorkflowInstanceAction.class));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    verify(workflowInstances, never()).updateWorkflowInstance(any(WorkflowInstance.class), any(WorkflowInstanceAction.class),
+        eq(Optional.empty()));
   }
 
   @Test
@@ -125,9 +126,9 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.actionDescription = "my desc";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -140,9 +141,9 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.state = "newState";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -156,9 +157,9 @@ public class WorkflowInstanceResourceTest {
     req.state = "newState";
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -172,9 +173,9 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.nextActivationTime = new DateTime(2014, 11, 12, 17, 55, 0);
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(nullValue()));
     assertThat(instance.status, is(nullValue()));
@@ -189,9 +190,9 @@ public class WorkflowInstanceResourceTest {
     req.nextActivationTime = new DateTime(2014, 11, 12, 17, 55, 0);
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(nullValue()));
     assertThat(instance.status, is(nullValue()));
@@ -206,9 +207,9 @@ public class WorkflowInstanceResourceTest {
     req.stateVariables.put("foo", "bar");
     req.stateVariables.put("textNode", new TextNode("text"));
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.getStateVariable("foo"), is("bar"));
     assertThat(instance.getStateVariable("textNode"), is("\"text\""));
@@ -221,9 +222,9 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.businessKey = "modifiedKey";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.businessKey, is(req.businessKey));
     WorkflowInstanceAction action = actionCaptor.getValue();
@@ -237,9 +238,9 @@ public class WorkflowInstanceResourceTest {
     req.businessKey = "modifiedKey";
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture());
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.businessKey, is(req.businessKey));
     WorkflowInstanceAction action = actionCaptor.getValue();

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
@@ -1,10 +1,10 @@
 package io.nflow.rest.v1.jaxrs;
 
 import static io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
-import static java.util.Collections.emptySet;
-import static java.util.EnumSet.allOf;
 import static jakarta.ws.rs.core.Response.Status.CREATED;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static java.util.Collections.emptySet;
+import static java.util.EnumSet.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -25,8 +25,6 @@ import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-
-import jakarta.ws.rs.core.Response;
 
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +58,7 @@ import io.nflow.rest.v1.msg.ListWorkflowInstanceResponse;
 import io.nflow.rest.v1.msg.SetSignalRequest;
 import io.nflow.rest.v1.msg.SetSignalResponse;
 import io.nflow.rest.v1.msg.UpdateWorkflowInstanceRequest;
+import jakarta.ws.rs.core.Response;
 
 @ExtendWith(MockitoExtension.class)
 public class WorkflowInstanceResourceTest {
@@ -95,7 +94,7 @@ public class WorkflowInstanceResourceTest {
     resource = new WorkflowInstanceResource(workflowInstances, createWorkflowConverter, listWorkflowConverter,
         workflowInstanceFactory, workflowInstanceDao);
     lenient().when(workflowInstanceFactory.newWorkflowInstanceBuilder())
-        .thenReturn(new WorkflowInstance.Builder(new ObjectStringMapper(ObjectMapper::new)));
+    .thenReturn(new WorkflowInstance.Builder(new ObjectStringMapper(ObjectMapper::new)));
   }
 
   @Test
@@ -126,9 +125,10 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.actionDescription = "my desc";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -141,9 +141,10 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.state = "newState";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -157,9 +158,10 @@ public class WorkflowInstanceResourceTest {
     req.state = "newState";
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -173,9 +175,10 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.nextActivationTime = new DateTime(2014, 11, 12, 17, 55, 0);
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(nullValue()));
     assertThat(instance.status, is(nullValue()));
@@ -190,9 +193,10 @@ public class WorkflowInstanceResourceTest {
     req.nextActivationTime = new DateTime(2014, 11, 12, 17, 55, 0);
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(nullValue()));
     assertThat(instance.status, is(nullValue()));
@@ -207,9 +211,10 @@ public class WorkflowInstanceResourceTest {
     req.stateVariables.put("foo", "bar");
     req.stateVariables.put("textNode", new TextNode("text"));
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.getStateVariable("foo"), is("bar"));
     assertThat(instance.getStateVariable("textNode"), is("\"text\""));
@@ -222,9 +227,10 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.businessKey = "modifiedKey";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.businessKey, is(req.businessKey));
     WorkflowInstanceAction action = actionCaptor.getValue();
@@ -238,9 +244,10 @@ public class WorkflowInstanceResourceTest {
     req.businessKey = "modifiedKey";
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
 
-    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(), eq(Optional.empty()));
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.businessKey, is(req.businessKey));
     WorkflowInstanceAction action = actionCaptor.getValue();
@@ -304,7 +311,7 @@ public class WorkflowInstanceResourceTest {
   @Test
   public void fetchingNonExistingWorkflowReturnsNotFound() {
     when(workflowInstances.getWorkflowInstance(42, emptySet(), null, true))
-        .thenThrow(new NflowNotFoundException("Workflow instance", 42, new Exception()));
+    .thenThrow(new NflowNotFoundException("Workflow instance", 42, new Exception()));
     try (Response response = resource.fetchWorkflowInstance(42, null, null, null, true)) {
       assertThat(response.getStatus(), is(equalTo(NOT_FOUND.getStatusCode())));
       assertThat(((ErrorResponse) response.getEntity()).error, is(equalTo("Workflow instance 42 not found")));
@@ -319,7 +326,7 @@ public class WorkflowInstanceResourceTest {
     ListWorkflowInstanceResponse resp = mock(ListWorkflowInstanceResponse.class);
     when(listWorkflowConverter.convert(eq(instance), any(Set.class), eq(false))).thenReturn(resp);
     ListWorkflowInstanceResponse result = getEntity(() -> resource.fetchWorkflowInstance(42, null, null, null, false)
-    );
+        );
     verify(workflowInstances).getWorkflowInstance(42, emptySet(), null, false);
     assertEquals(resp, result);
   }
@@ -334,7 +341,7 @@ public class WorkflowInstanceResourceTest {
     when(listWorkflowConverter.convert(eq(instance), any(Set.class), eq(false))).thenReturn(resp);
     ListWorkflowInstanceResponse result = getEntity(
         () -> resource.fetchWorkflowInstance(42, allOf(ApiWorkflowInstanceInclude.class), null, 10L, false)
-    );
+        );
     verify(workflowInstances).getWorkflowInstance(42, includes, 10L, false);
     assertEquals(resp, result);
   }

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
@@ -1,5 +1,7 @@
 package io.nflow.rest.v1.jaxrs;
 
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.allowNormal;
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.doNotValidate;
 import static io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
 import static jakarta.ws.rs.core.Response.Status.CREATED;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
@@ -94,7 +96,7 @@ public class WorkflowInstanceResourceTest {
     resource = new WorkflowInstanceResource(workflowInstances, createWorkflowConverter, listWorkflowConverter,
         workflowInstanceFactory, workflowInstanceDao);
     lenient().when(workflowInstanceFactory.newWorkflowInstanceBuilder())
-    .thenReturn(new WorkflowInstance.Builder(new ObjectStringMapper(ObjectMapper::new)));
+        .thenReturn(new WorkflowInstance.Builder(new ObjectStringMapper(ObjectMapper::new)));
   }
 
   @Test
@@ -115,9 +117,9 @@ public class WorkflowInstanceResourceTest {
   @Test
   public void whenUpdatingWithoutParametersNothingHappens() {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
-    makeRequest(() -> resource.updateWorkflowInstance(3, null, req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, null, null, req));
     verify(workflowInstances, never()).updateWorkflowInstance(any(WorkflowInstance.class), any(WorkflowInstanceAction.class),
-        eq(Optional.empty()));
+        eq(Optional.empty()), eq(doNotValidate));
   }
 
   @Test
@@ -125,13 +127,42 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.actionDescription = "my desc";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
+    WorkflowInstanceAction action = actionCaptor.getValue();
+    assertThat(action.stateText, is(req.actionDescription));
+  }
+
+  @Test
+  public void whenUpdatingWithValidationModeItIsForwardedToService() {
+    UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
+    req.actionDescription = "my desc";
+
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", allowNormal, req));
+
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.of("expectedState")), eq(allowNormal));
+    WorkflowInstance instance = instanceCaptor.getValue();
+    assertThat(instance.state, is(req.state));
+    assertThat(instance.status, is(nullValue()));
+    WorkflowInstanceAction action = actionCaptor.getValue();
+    assertThat(action.stateText, is(req.actionDescription));
+  }
+
+  @Test
+  public void whenUpdatingWithBlankExpectedStateItIsTreatedAsMissing() {
+    UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
+    req.actionDescription = "my desc";
+
+    makeRequest(() -> resource.updateWorkflowInstance(3, "   ", null, req));
+
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.empty()), eq(doNotValidate));
     WorkflowInstanceAction action = actionCaptor.getValue();
     assertThat(action.stateText, is(req.actionDescription));
   }
@@ -141,10 +172,10 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.state = "newState";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -158,10 +189,10 @@ public class WorkflowInstanceResourceTest {
     req.state = "newState";
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(req.state));
     assertThat(instance.status, is(nullValue()));
@@ -175,10 +206,10 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.nextActivationTime = new DateTime(2014, 11, 12, 17, 55, 0);
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(nullValue()));
     assertThat(instance.status, is(nullValue()));
@@ -193,10 +224,10 @@ public class WorkflowInstanceResourceTest {
     req.nextActivationTime = new DateTime(2014, 11, 12, 17, 55, 0);
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.state, is(nullValue()));
     assertThat(instance.status, is(nullValue()));
@@ -211,10 +242,10 @@ public class WorkflowInstanceResourceTest {
     req.stateVariables.put("foo", "bar");
     req.stateVariables.put("textNode", new TextNode("text"));
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.getStateVariable("foo"), is("bar"));
     assertThat(instance.getStateVariable("textNode"), is("\"text\""));
@@ -227,10 +258,10 @@ public class WorkflowInstanceResourceTest {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.businessKey = "modifiedKey";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.businessKey, is(req.businessKey));
     WorkflowInstanceAction action = actionCaptor.getValue();
@@ -244,10 +275,10 @@ public class WorkflowInstanceResourceTest {
     req.businessKey = "modifiedKey";
     req.actionDescription = "description";
 
-    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", req));
+    makeRequest(() -> resource.updateWorkflowInstance(3, "expectedState", null, req));
 
     verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
-        eq(Optional.of("expectedState")));
+        eq(Optional.of("expectedState")), eq(doNotValidate));
     WorkflowInstance instance = instanceCaptor.getValue();
     assertThat(instance.businessKey, is(req.businessKey));
     WorkflowInstanceAction action = actionCaptor.getValue();
@@ -311,7 +342,7 @@ public class WorkflowInstanceResourceTest {
   @Test
   public void fetchingNonExistingWorkflowReturnsNotFound() {
     when(workflowInstances.getWorkflowInstance(42, emptySet(), null, true))
-    .thenThrow(new NflowNotFoundException("Workflow instance", 42, new Exception()));
+        .thenThrow(new NflowNotFoundException("Workflow instance", 42, new Exception()));
     try (Response response = resource.fetchWorkflowInstance(42, null, null, null, true)) {
       assertThat(response.getStatus(), is(equalTo(NOT_FOUND.getStatusCode())));
       assertThat(((ErrorResponse) response.getEntity()).error, is(equalTo("Workflow instance 42 not found")));
@@ -325,8 +356,7 @@ public class WorkflowInstanceResourceTest {
     when(workflowInstances.getWorkflowInstance(42, emptySet(), null, false)).thenReturn(instance);
     ListWorkflowInstanceResponse resp = mock(ListWorkflowInstanceResponse.class);
     when(listWorkflowConverter.convert(eq(instance), any(Set.class), eq(false))).thenReturn(resp);
-    ListWorkflowInstanceResponse result = getEntity(() -> resource.fetchWorkflowInstance(42, null, null, null, false)
-        );
+    ListWorkflowInstanceResponse result = getEntity(() -> resource.fetchWorkflowInstance(42, null, null, null, false));
     verify(workflowInstances).getWorkflowInstance(42, emptySet(), null, false);
     assertEquals(resp, result);
   }
@@ -340,8 +370,7 @@ public class WorkflowInstanceResourceTest {
     ListWorkflowInstanceResponse resp = mock(ListWorkflowInstanceResponse.class);
     when(listWorkflowConverter.convert(eq(instance), any(Set.class), eq(false))).thenReturn(resp);
     ListWorkflowInstanceResponse result = getEntity(
-        () -> resource.fetchWorkflowInstance(42, allOf(ApiWorkflowInstanceInclude.class), null, 10L, false)
-        );
+        () -> resource.fetchWorkflowInstance(42, allOf(ApiWorkflowInstanceInclude.class), null, 10L, false));
     verify(workflowInstances).getWorkflowInstance(42, includes, 10L, false);
     assertEquals(resp, result);
   }

--- a/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
+++ b/nflow-rest-api-jax-rs/src/test/java/io/nflow/rest/v1/jaxrs/WorkflowInstanceResourceTest.java
@@ -168,6 +168,19 @@ public class WorkflowInstanceResourceTest {
   }
 
   @Test
+  public void whenUpdatingWithBlankExpectedStateValidationModeIsForwarded() {
+    UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
+    req.actionDescription = "my desc";
+
+    makeRequest(() -> resource.updateWorkflowInstance(3, "   ", allowNormal, req));
+
+    verify(workflowInstances).updateWorkflowInstance(instanceCaptor.capture(), actionCaptor.capture(),
+        eq(Optional.empty()), eq(allowNormal));
+    WorkflowInstanceAction action = actionCaptor.getValue();
+    assertThat(action.stateText, is(req.actionDescription));
+  }
+
+  @Test
   public void whenUpdatingStateUpdateWorkflowInstanceWorks() {
     UpdateWorkflowInstanceRequest req = new UpdateWorkflowInstanceRequest();
     req.state = "newState";

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
@@ -114,7 +114,7 @@ public class WorkflowInstanceResource extends SpringWebResource {
       @RequestParam(value = "expectedState", required = false) @Parameter(
           description = "Expected current state of workflow instance") String expectedState,
       @RequestParam(value = "validationMode", required = false) @Parameter(
-          description = "Validation mode for state transition check, ignored when expectedState is not given") StateTransitionValidationMode validationMode,
+          description = "Validation mode for state transition check; must be doNotValidate when expectedState is not given") StateTransitionValidationMode validationMode,
       @RequestBody @Valid @Parameter(description = "Submitted workflow instance information",
           required = true) UpdateWorkflowInstanceRequest req) {
     return handleExceptions(() -> wrapBlocking(() -> {

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
@@ -17,9 +17,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import jakarta.inject.Inject;
-import jakarta.validation.Valid;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.nflow.engine.internal.dao.WorkflowInstanceDao;
 import io.nflow.engine.service.WorkflowInstanceInclude;
 import io.nflow.engine.service.WorkflowInstanceService;
+import io.nflow.engine.workflow.definition.StateTransitionValidationMode;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
 import io.nflow.engine.workflow.instance.WorkflowInstance.WorkflowInstanceStatus;
 import io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType;
@@ -57,6 +55,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -107,16 +107,19 @@ public class WorkflowInstanceResource extends SpringWebResource {
   @ApiResponses({ @ApiResponse(responseCode = "204", description = "If update was successful"),
       @ApiResponse(responseCode = "400",
           description = "If instance could not be updated, for example when state variable value was too long"),
-      @ApiResponse(responseCode = "409", description = "If workflow was executing and no update was done") })
+      @ApiResponse(responseCode = "409",
+          description = "If no update was done, for example because workflow was executing, expected state did not match, or requested state transition was not allowed") })
   public Mono<ResponseEntity<?>> updateWorkflowInstance(
       @Parameter(description = "Internal id for workflow instance") @PathVariable("id") long id,
       @RequestParam(value = "expectedState", required = false) @Parameter(
           description = "Expected current state of workflow instance") String expectedState,
+      @RequestParam(value = "validationMode", required = false) @Parameter(
+          description = "Validation mode for state transition check, ignored when expectedState is not given") StateTransitionValidationMode validationMode,
       @RequestBody @Valid @Parameter(description = "Submitted workflow instance information",
           required = true) UpdateWorkflowInstanceRequest req) {
     return handleExceptions(() -> wrapBlocking(() -> {
       boolean updated = super.updateWorkflowInstance(id, req, workflowInstanceFactory, workflowInstances, workflowInstanceDao,
-          ofNullable(expectedState));
+                    expectedState, validationMode);
       return (updated ? noContent() : status(CONFLICT)).build();
     }));
   }

--- a/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
+++ b/nflow-rest-api-spring-web/src/main/java/io/nflow/rest/v1/springweb/WorkflowInstanceResource.java
@@ -110,10 +110,13 @@ public class WorkflowInstanceResource extends SpringWebResource {
       @ApiResponse(responseCode = "409", description = "If workflow was executing and no update was done") })
   public Mono<ResponseEntity<?>> updateWorkflowInstance(
       @Parameter(description = "Internal id for workflow instance") @PathVariable("id") long id,
+      @RequestParam(value = "expectedState", required = false) @Parameter(
+          description = "Expected current state of workflow instance") String expectedState,
       @RequestBody @Valid @Parameter(description = "Submitted workflow instance information",
           required = true) UpdateWorkflowInstanceRequest req) {
     return handleExceptions(() -> wrapBlocking(() -> {
-      boolean updated = super.updateWorkflowInstance(id, req, workflowInstanceFactory, workflowInstances, workflowInstanceDao);
+      boolean updated = super.updateWorkflowInstance(id, req, workflowInstanceFactory, workflowInstances, workflowInstanceDao,
+          ofNullable(expectedState));
       return (updated ? noContent() : status(CONFLICT)).build();
     }));
   }

--- a/nflow-tests/src/main/java/io/nflow/tests/demo/DemoServer.java
+++ b/nflow-tests/src/main/java/io/nflow/tests/demo/DemoServer.java
@@ -60,7 +60,7 @@ public class DemoServer {
     instance = workflowInstanceService.getWorkflowInstance(id, emptySet(), null);
     WorkflowInstanceAction action = new WorkflowInstanceAction.Builder(instance).setType(externalChange).setExecutionEnd(now())
         .build();
-    workflowInstanceService.updateWorkflowInstance(instance, action);
+    workflowInstanceService.updateWorkflowInstance(instance, action, Optional.empty());
     instance = workflowInstanceService.getWorkflowInstance(id, EnumSet.of(WorkflowInstanceInclude.ACTIONS), 1L);
     long actionId = instance.actions.get(0).id;
     WorkflowInstance child = new WorkflowInstance.Builder().setType(DEMO_WORKFLOW_TYPE).setState(BEGIN.name())

--- a/nflow-tests/src/main/java/io/nflow/tests/demo/DemoServer.java
+++ b/nflow-tests/src/main/java/io/nflow/tests/demo/DemoServer.java
@@ -4,6 +4,7 @@ import static io.nflow.engine.config.Profiles.JMX;
 import static io.nflow.engine.workflow.curated.BulkWorkflow.SPLIT_WORK;
 import static io.nflow.engine.workflow.curated.BulkWorkflow.VAR_CHILD_DATA;
 import static io.nflow.engine.workflow.curated.BulkWorkflow.VAR_CONCURRENCY;
+import static io.nflow.engine.workflow.definition.StateTransitionValidationMode.allowNormal;
 import static io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType.externalChange;
 import static io.nflow.tests.demo.SpringApplicationContext.applicationContext;
 import static io.nflow.tests.demo.workflow.DemoBulkWorkflow.DEMO_BULK_WORKFLOW_TYPE;
@@ -60,7 +61,7 @@ public class DemoServer {
     instance = workflowInstanceService.getWorkflowInstance(id, emptySet(), null);
     WorkflowInstanceAction action = new WorkflowInstanceAction.Builder(instance).setType(externalChange).setExecutionEnd(now())
         .build();
-    workflowInstanceService.updateWorkflowInstance(instance, action, Optional.empty());
+    workflowInstanceService.updateWorkflowInstance(instance, action, Optional.of(instance.state), allowNormal);
     instance = workflowInstanceService.getWorkflowInstance(id, EnumSet.of(WorkflowInstanceInclude.ACTIONS), 1L);
     long actionId = instance.actions.get(0).id;
     WorkflowInstance child = new WorkflowInstance.Builder().setType(DEMO_WORKFLOW_TYPE).setState(BEGIN.name())


### PR DESCRIPTION
- `nflow-engine`
  - Add optional state transition validation for workflow instance updates.
    - `WorkflowInstanceService.updateWorkflowInstance` now takes optional `expectedState` and returns `false` when transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.
    - Add `WorkflowDefinition.isAllowedStateTransition` helper for checking allowed transitions.
- `nflow-rest-api`
  - Add optional state transition validation for workflow instance updates.
    - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` transition from expected state to requested new state is not allowed by the workflow definition, or when the expected state does not match the instance state in the database.