### PR TITLE
POTENTIALLY BREAKING CHANGE: Make setVariable throw error when called for @StateVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
     - `validationMode` must be `doNotValidate` when `expectedState` is not given.
     - Keep `WorkflowInstanceService.updateWorkflowInstance` that does not take `expectedState` and `validationMode` parameters to maintain backwards compatibility, but mark it as deprecated.
     - Add `WorkflowDefinition.isAllowedStateTransition` helper for checking allowed transitions.
-  - `StateExecution.setVariable(...)` now throws error if called for any `@StateVar` state variables.
-    - Either stop calling `StateExecution.setVariable(...)` or remove `@StateVar` state variable.
+  - `StateExecution.setVariable(...)` now throws error if called for any `@StateVar` state variable of the method.
+    - Either stop calling `StateExecution.setVariable(...)` or remove `@StateVar` state variable from the method.
     - Previous behavior: `StateExecution.setVariable(...)` was silently ignored.
 - `nflow-rest-api`
   - Add optional expected state and state transition validations for workflow instance updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 **Highlights**
 
+- POTENTIALLY BREAKING CHANGE: `StateExecution.setVariable(...)` throws error when called for `@StateVar` state variables (see details below)
+
 **Details**
 
 - `nflow-engine`
@@ -11,6 +13,9 @@
     - `validationMode` must be `doNotValidate` when `expectedState` is not given.
     - Keep `WorkflowInstanceService.updateWorkflowInstance` that does not take `expectedState` and `validationMode` parameters to maintain backwards compatibility, but mark it as deprecated.
     - Add `WorkflowDefinition.isAllowedStateTransition` helper for checking allowed transitions.
+  - `StateExecution.setVariable(...)` now throws error if called for any `@StateVar` state variables.
+    - Either stop calling `StateExecution.setVariable(...)` or remove `@StateVar` state variable.
+    - Previous behavior: `StateExecution.setVariable(...)` was silently ignored.
 - `nflow-rest-api`
   - Add optional expected state and state transition validations for workflow instance updates.
     - Workflow instance update endpoints now take optional `expectedState` query parameter, pass it through to `WorkflowInstanceService.updateWorkflowInstance`, and return `HTTP 409 Conflict` when expected state does not match the workflow instance state in the database.

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
@@ -556,7 +556,7 @@ class WorkflowStateProcessor implements Runnable {
       } else {
         execution.setNextState(nextAction.getNextState());
       }
-      objectMapper.storeArguments(execution, method, args);
+      objectMapper.storeArguments(method, args, execution::setVariableInternal);
       return nextAction;
     }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/executor/WorkflowStateProcessor.java
@@ -154,7 +154,7 @@ class WorkflowStateProcessor implements Runnable {
     int subsequentStateExecutions = 0;
     while (instance.status == executing && !shutdownRequested.get()) {
       startTime = now();
-      StateExecutionImpl execution = new StateExecutionImpl(instance, objectMapper, workflowInstanceDao,
+      StateExecutionImpl execution = new StateExecutionImpl(instance, definition, objectMapper, workflowInstanceDao,
           workflowInstancePreProcessor, workflowInstances);
       listenerContext = new ListenerContext(definition, instance, execution);
       WorkflowInstanceAction.Builder actionBuilder = new WorkflowInstanceAction.Builder(instance);
@@ -192,10 +192,10 @@ class WorkflowStateProcessor implements Runnable {
             }
           }
           execution.setNextStateReason(reason);
-          execution.handleRetryAfter(retryAfter, definition);
+          execution.handleRetryAfter(retryAfter);
         } else {
           logger.error("Handler threw an exception and retrying is not allowed, going to failure state.", thrown);
-          execution.handleFailure(definition, "Handler threw an exception and retrying is not allowed");
+          execution.handleFailure("Handler threw an exception and retrying is not allowed");
         }
       } finally {
         if (saveInstanceState) {
@@ -552,7 +552,7 @@ class WorkflowStateProcessor implements Runnable {
       } else if (nextAction.isRetry()) {
         execution.setNextState(currentState);
         execution.setRetry(true);
-        execution.handleRetryAfter(nextAction.getActivation(), definition);
+        execution.handleRetryAfter(nextAction.getActivation());
       } else {
         execution.setNextState(nextAction.getNextState());
       }

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
@@ -5,9 +5,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 
-import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
-import jakarta.inject.Inject;
-
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,10 +12,12 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.nflow.engine.config.EngineConfiguration.EngineObjectMapperSupplier;
 import io.nflow.engine.config.NFlow;
 import io.nflow.engine.internal.workflow.WorkflowStateMethod.StateParameter;
 import io.nflow.engine.workflow.definition.Mutable;
 import io.nflow.engine.workflow.definition.StateExecution;
+import jakarta.inject.Inject;
 
 @Component
 public class ObjectStringMapper {
@@ -72,8 +71,7 @@ public class ObjectStringMapper {
   }
 
   @SuppressWarnings("unchecked")
-  public void storeArguments(StateExecution execution,
-      WorkflowStateMethod method, Object[] args) {
+  public void storeArguments(StateExecution execution, WorkflowStateMethod method, Object[] args) {
     StateParameter[] params = method.params;
     for (int i = 0; i < params.length; i++) {
       StateParameter param = params[i];
@@ -96,7 +94,7 @@ public class ObjectStringMapper {
       } else {
         sVal = convertFromObject(param.key, value);
       }
-      execution.setVariable(param.key, sVal);
+      execution.setVariableInternal(param.key, sVal);
     }
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/ObjectStringMapper.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.util.function.BiConsumer;
 
 import org.springframework.stereotype.Component;
 
@@ -71,7 +72,7 @@ public class ObjectStringMapper {
   }
 
   @SuppressWarnings("unchecked")
-  public void storeArguments(StateExecution execution, WorkflowStateMethod method, Object[] args) {
+  public void storeArguments(WorkflowStateMethod method, Object[] args, BiConsumer<String, String> setVariable) {
     StateParameter[] params = method.params;
     for (int i = 0; i < params.length; i++) {
       StateParameter param = params[i];
@@ -94,7 +95,7 @@ public class ObjectStringMapper {
       } else {
         sVal = convertFromObject(param.key, value);
       }
-      execution.setVariableInternal(param.key, sVal);
+      setVariable.accept(param.key, sVal);
     }
   }
 

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StateExecutionImpl.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StateExecutionImpl.java
@@ -10,12 +10,12 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.springframework.util.Assert;
 
-import jakarta.annotation.Nonnull;
 import io.nflow.engine.internal.dao.WorkflowInstanceDao;
 import io.nflow.engine.model.ModelObject;
 import io.nflow.engine.service.WorkflowInstanceService;
@@ -25,11 +25,13 @@ import io.nflow.engine.workflow.definition.WorkflowState;
 import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
 import io.nflow.engine.workflow.instance.WorkflowInstanceAction.WorkflowActionType;
+import jakarta.annotation.Nonnull;
 
 public class StateExecutionImpl extends ModelObject implements StateExecution {
 
   private static final Logger LOG = getLogger(StateExecutionImpl.class);
   private final WorkflowInstance instance;
+  private final WorkflowDefinition definition;
   private final ObjectStringMapper objectMapper;
   private final WorkflowInstanceDao workflowDao;
   private final WorkflowInstancePreProcessor workflowInstancePreProcessor;
@@ -49,9 +51,11 @@ public class StateExecutionImpl extends ModelObject implements StateExecution {
   private boolean historyCleaningForced = false;
   private String businessKey;
 
-  public StateExecutionImpl(WorkflowInstance instance, ObjectStringMapper objectMapper, WorkflowInstanceDao workflowDao,
+  public StateExecutionImpl(WorkflowInstance instance, WorkflowDefinition definition, ObjectStringMapper objectMapper,
+      WorkflowInstanceDao workflowDao,
       WorkflowInstancePreProcessor workflowInstancePreProcessor, WorkflowInstanceService workflowInstanceService) {
     this.instance = instance;
+    this.definition = definition;
     this.objectMapper = objectMapper;
     this.workflowDao = workflowDao;
     this.workflowInstancePreProcessor = workflowInstancePreProcessor;
@@ -135,6 +139,9 @@ public class StateExecutionImpl extends ModelObject implements StateExecution {
       return;
     }
     workflowDao.checkStateVariableValueLength(name, value);
+    WorkflowStateMethod method = definition.getMethod(instance.state);
+    Assert.isTrue(method == null || Stream.of(method.params).noneMatch(p -> p.key.equals(name)),
+        "Calling setVariable with name that matches @StateVar argument is not allowed");
     instance.stateVariables.put(name, value);
   }
 
@@ -142,6 +149,16 @@ public class StateExecutionImpl extends ModelObject implements StateExecution {
   public void setVariable(@Nonnull String name, Object value) {
     requireNonNull(name, "State variable name cannot be null");
     setVariable(name, objectMapper.convertFromObject(name, value));
+  }
+
+  @Override
+  public void setVariableInternal(@Nonnull String name, String value) {
+    requireNonNull(name, "State variable name cannot be null");
+    if (value == null) {
+      return;
+    }
+    workflowDao.checkStateVariableValueLength(name, value);
+    instance.stateVariables.put(name, value);
   }
 
   public void setNextActivation(DateTime activation) {
@@ -285,16 +302,16 @@ public class StateExecutionImpl extends ModelObject implements StateExecution {
     return historyCleaningForced;
   }
 
-  public void handleRetryAfter(DateTime activation, WorkflowDefinition definition) {
+  public void handleRetryAfter(DateTime activation) {
     if (getRetries() >= definition.getSettings().maxRetries) {
       isRetryCountExceeded = true;
-      handleFailure(definition, "Max retry count exceeded");
+      handleFailure("Max retry count exceeded");
     } else {
       setNextActivation(activation);
     }
   }
 
-  public void handleFailure(WorkflowDefinition definition, String failureReason) {
+  public void handleFailure(String failureReason) {
     setRetry(false);
     String currentStateName = getCurrentStateName();
     WorkflowState failureState = definition.getFailureTransitions().get(currentStateName);

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StateExecutionImpl.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StateExecutionImpl.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -140,7 +139,7 @@ public class StateExecutionImpl extends ModelObject implements StateExecution {
     }
     workflowDao.checkStateVariableValueLength(name, value);
     WorkflowStateMethod method = definition.getMethod(instance.state);
-    Assert.isTrue(method == null || Stream.of(method.params).noneMatch(p -> p.key.equals(name)),
+    Assert.isTrue(method == null || !method.hasParameter(name),
         "Calling setVariable with name that matches @StateVar argument is not allowed");
     instance.stateVariables.put(name, value);
   }

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StateExecutionImpl.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/StateExecutionImpl.java
@@ -150,7 +150,6 @@ public class StateExecutionImpl extends ModelObject implements StateExecution {
     setVariable(name, objectMapper.convertFromObject(name, value));
   }
 
-  @Override
   public void setVariableInternal(@Nonnull String name, String value) {
     requireNonNull(name, "State variable name cannot be null");
     if (value == null) {

--- a/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowStateMethod.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/internal/workflow/WorkflowStateMethod.java
@@ -2,12 +2,17 @@ package io.nflow.engine.internal.workflow;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.stream.Stream;
 
 import io.nflow.engine.model.ModelObject;
 
 public class WorkflowStateMethod extends ModelObject {
   public final Method method;
   final StateParameter[] params;
+
+  public boolean hasParameter(String name) {
+    return Stream.of(params).anyMatch(p -> p.key.equals(name));
+  }
 
   static class StateParameter extends ModelObject {
     final String key;

--- a/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/service/WorkflowInstanceService.java
@@ -147,7 +147,7 @@ public class WorkflowInstanceService {
     Assert.notNull(action, "Workflow instance action can not be null");
     Assert.notNull(expectedState, "Expected state can not be null");
     Assert.notNull(validationMode, "Validation mode can not be null");
-    Assert.isTrue(expectedState.isPresent() || validationMode == StateTransitionValidationMode.doNotValidate,
+    Assert.isTrue(validationMode == StateTransitionValidationMode.doNotValidate || expectedState.isPresent(),
         "Validation mode must be doNotValidate when expected state is not given");
     Assert.notNull(workflowDefinitionService, "workflowDefinitionService can not be null");
     try {

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
@@ -3,9 +3,9 @@ package io.nflow.engine.workflow.definition;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.annotation.Nonnull;
 import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
+import jakarta.annotation.Nonnull;
 
 /**
  * Provides access to workflow instance information.
@@ -193,4 +193,9 @@ public interface StateExecution {
    * @return True if unfinished child workflow instances are found, false otherwise.
    */
   boolean hasUnfinishedChildWorkflows();
+
+  /**
+   * For internal usage (ObjectStringMapper) only.
+   */
+  void setVariableInternal(String name, String value);
 }

--- a/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
+++ b/nflow-engine/src/main/java/io/nflow/engine/workflow/definition/StateExecution.java
@@ -193,9 +193,4 @@ public interface StateExecution {
    * @return True if unfinished child workflow instances are found, false otherwise.
    */
   boolean hasUnfinishedChildWorkflows();
-
-  /**
-   * For internal usage (ObjectStringMapper) only.
-   */
-  void setVariableInternal(String name, String value);
 }

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
@@ -267,8 +267,8 @@ public class StateExecutionImplTest {
   @Test
   public void setVariableThrowsWhenNameMatchesStateVar() {
     WorkflowDefinition definition = mock(WorkflowDefinition.class);
-    WorkflowStateMethod method = new WorkflowStateMethod(null,
-        new WorkflowStateMethod.StateParameter("foo", String.class, null, false, false));
+    WorkflowStateMethod method = mock(WorkflowStateMethod.class);
+    when(method.hasParameter("foo")).thenReturn(true);
     when(definition.getMethod("myState")).thenReturn(method);
     createExecution(definition);
 
@@ -279,8 +279,8 @@ public class StateExecutionImplTest {
   @Test
   public void setVariableObjectThrowsWhenNameMatchesStateVar() {
     WorkflowDefinition definition = mock(WorkflowDefinition.class);
-    WorkflowStateMethod method = new WorkflowStateMethod(null,
-        new WorkflowStateMethod.StateParameter("foo", Data.class, null, false, true));
+    WorkflowStateMethod method = mock(WorkflowStateMethod.class);
+    when(method.hasParameter("foo")).thenReturn(true);
     when(definition.getMethod("myState")).thenReturn(method);
     Data testData = new Data(42, "hello");
     String testValue = "testValue";
@@ -289,6 +289,20 @@ public class StateExecutionImplTest {
 
     assertThrows(IllegalArgumentException.class, () -> execution.setVariable("foo", testData));
     verify(workflowDao).checkStateVariableValueLength("foo", testValue);
+  }
+
+  @Test
+  public void setVariableDoesNotThrowWhenNameDoesNotMatchStateVar() {
+    WorkflowDefinition definition = mock(WorkflowDefinition.class);
+    WorkflowStateMethod method = mock(WorkflowStateMethod.class);
+    when(method.hasParameter("foo")).thenReturn(false);
+    when(definition.getMethod("myState")).thenReturn(method);
+    createExecution(definition);
+
+    execution.setVariable("foo", "bar");
+
+    assertThat(instance.stateVariables, hasEntry("foo", "bar"));
+    verify(workflowDao).checkStateVariableValueLength("foo", "bar");
   }
 
   @Test

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/StateExecutionImplTest.java
@@ -34,6 +34,7 @@ import io.nflow.engine.service.WorkflowInstanceService;
 import io.nflow.engine.workflow.definition.StateExecution;
 import io.nflow.engine.workflow.definition.TestDefinition;
 import io.nflow.engine.workflow.definition.TestWorkflow;
+import io.nflow.engine.workflow.definition.WorkflowDefinition;
 import io.nflow.engine.workflow.definition.WorkflowState;
 import io.nflow.engine.workflow.instance.QueryWorkflowInstances;
 import io.nflow.engine.workflow.instance.WorkflowInstance;
@@ -67,7 +68,12 @@ public class StateExecutionImplTest {
   }
 
   private void createExecution() {
-    execution = new StateExecutionImpl(instance, objectStringMapper, workflowDao, workflowInstancePreProcessor,
+    execution = new StateExecutionImpl(instance, new TestDefinition("test", TestDefinition.START_1), objectStringMapper,
+        workflowDao, workflowInstancePreProcessor, workflowInstanceService);
+  }
+
+  private void createExecution(WorkflowDefinition definition) {
+    execution = new StateExecutionImpl(instance, definition, objectStringMapper, workflowDao, workflowInstancePreProcessor,
         workflowInstanceService);
   }
 
@@ -259,6 +265,56 @@ public class StateExecutionImplTest {
   }
 
   @Test
+  public void setVariableThrowsWhenNameMatchesStateVar() {
+    WorkflowDefinition definition = mock(WorkflowDefinition.class);
+    WorkflowStateMethod method = new WorkflowStateMethod(null,
+        new WorkflowStateMethod.StateParameter("foo", String.class, null, false, false));
+    when(definition.getMethod("myState")).thenReturn(method);
+    createExecution(definition);
+
+    assertThrows(IllegalArgumentException.class, () -> execution.setVariable("foo", "bar"));
+    verify(workflowDao).checkStateVariableValueLength("foo", "bar");
+  }
+
+  @Test
+  public void setVariableObjectThrowsWhenNameMatchesStateVar() {
+    WorkflowDefinition definition = mock(WorkflowDefinition.class);
+    WorkflowStateMethod method = new WorkflowStateMethod(null,
+        new WorkflowStateMethod.StateParameter("foo", Data.class, null, false, true));
+    when(definition.getMethod("myState")).thenReturn(method);
+    Data testData = new Data(42, "hello");
+    String testValue = "testValue";
+    when(objectStringMapper.convertFromObject("foo", testData)).thenReturn(testValue);
+    createExecution(definition);
+
+    assertThrows(IllegalArgumentException.class, () -> execution.setVariable("foo", testData));
+    verify(workflowDao).checkStateVariableValueLength("foo", testValue);
+  }
+
+  @Test
+  public void setVariableInternalAllowsNameMatchingStateVar() {
+    WorkflowDefinition definition = mock(WorkflowDefinition.class);
+    createExecution(definition);
+
+    execution.setVariableInternal("foo", "bar");
+
+    assertThat(instance.stateVariables, hasEntry("foo", "bar"));
+    verify(workflowDao).checkStateVariableValueLength("foo", "bar");
+  }
+
+  @Test
+  public void setVariableInternalNullValueIsNoOp() {
+    execution.setVariableInternal("foo", null);
+
+    assertThat(instance.stateVariables.containsKey("foo"), is(false));
+  }
+
+  @Test
+  public void setVariableInternalNullNameThrowsException() {
+    assertThrows(NullPointerException.class, () -> execution.setVariableInternal(null, "bar"));
+  }
+
+  @Test
   public void getSignalWorks() {
     when(workflowDao.getSignal(instance.id)).thenReturn(Optional.of(42));
 
@@ -292,56 +348,54 @@ public class StateExecutionImplTest {
 
   @Test
   public void exceedingMaxRetriesInFailureStateGoesToErrorState() {
-    handleRetryMaxRetriesExceeded(TestDefinition.START_1, TestDefinition.FAILED);
+    handleRetryMaxRetriesExceeded(TestDefinition.FAILED);
     assertThat(execution.getNextState(), is(equalTo(TestDefinition.ERROR)));
     assertThat(execution.getNextActivation(), is(notNullValue()));
   }
 
   @Test
   public void exceedingMaxRetriesInNonFailureStateGoesToFailureState() {
-    handleRetryMaxRetriesExceeded(TestDefinition.START_1, TestDefinition.START_1);
+    handleRetryMaxRetriesExceeded(TestDefinition.START_1);
     assertThat(execution.getNextState(), is(equalTo(TestDefinition.FAILED)));
     assertThat(execution.getNextActivation(), is(notNullValue()));
   }
 
   @Test
   public void exceedingMaxRetriesInNonFailureStateGoesToErrorStateWhenNoFailureStateIsDefined() {
-    handleRetryMaxRetriesExceeded(TestDefinition.START_1, TestDefinition.START_2);
+    handleRetryMaxRetriesExceeded(TestDefinition.START_2);
     assertThat(execution.getNextState(), is(equalTo(TestDefinition.ERROR)));
     assertThat(execution.getNextActivation(), is(notNullValue()));
   }
 
   @Test
   public void exceedingMaxRetriesInErrorStateStopsProcessing() {
-    handleRetryMaxRetriesExceeded(TestDefinition.START_1, TestDefinition.ERROR);
+    handleRetryMaxRetriesExceeded(TestDefinition.ERROR);
     assertThat(execution.getNextState(), is(equalTo(TestDefinition.ERROR)));
     assertThat(execution.getNextActivation(), is(nullValue()));
   }
 
   @Test
   public void handleRetryAfterSetsActivationWhenMaxRetriesIsNotExceeded() {
-    TestWorkflow def = new TestWorkflow();
     instance = new WorkflowInstance.Builder().setId(99).setExternalId("ext").setState(TestWorkflow.START_WITHOUT_FAILURE)
         .setBusinessKey("business").build();
     createExecution();
 
-    execution.handleRetryAfter(tomorrow, def);
+    execution.handleRetryAfter(tomorrow);
 
     assertThat(execution.getNextState(), is(nullValue()));
     assertThat(execution.getNextActivation(), is(equalTo(tomorrow)));
   }
 
-  private void handleRetryMaxRetriesExceeded(WorkflowState initialState, WorkflowState currentState) {
-    TestDefinition def = new TestDefinition("x", initialState);
+  private void handleRetryMaxRetriesExceeded(WorkflowState currentState) {
     instance = new WorkflowInstance.Builder().setId(99).setExternalId("ext").setRetries(88).setState(currentState)
         .setBusinessKey("business").build();
     createExecution();
-    execution.handleRetryAfter(tomorrow, def);
+    execution.handleRetryAfter(tomorrow);
   }
 
   @Test
   public void handleFailureGoesToFailureState() {
-    handleFailure(TestDefinition.START_1, TestDefinition.START_1);
+    handleFailure(TestDefinition.START_1);
 
     assertThat(execution.getNextState(), is(equalTo(TestDefinition.FAILED)));
     assertThat(execution.getNextActivation(), is(notNullValue()));
@@ -350,7 +404,7 @@ public class StateExecutionImplTest {
 
   @Test
   public void handleFailureGoesToErrorStateWhenFailureStateIsNotDefined() {
-    handleFailure(TestDefinition.START_2, TestDefinition.START_2);
+    handleFailure(TestDefinition.START_2);
 
     assertThat(execution.isRetry(), is(false));
     assertThat(execution.getNextState(), is(equalTo(TestDefinition.ERROR)));
@@ -360,7 +414,7 @@ public class StateExecutionImplTest {
 
   @Test
   public void handleFailureStopsProcessingWhenProcessingErrorState() {
-    handleFailure(TestDefinition.START_2, TestDefinition.ERROR);
+    handleFailure(TestDefinition.ERROR);
 
     assertThat(execution.isRetry(), is(false));
     assertThat(execution.getNextState(), is(equalTo(TestDefinition.ERROR)));
@@ -379,11 +433,10 @@ public class StateExecutionImplTest {
     assertThat(execution.getNewBusinessKey(), is(equalTo(newKey)));
   }
 
-  private void handleFailure(WorkflowState initialState, WorkflowState currentState) {
-    TestDefinition def = new TestDefinition("x", initialState);
+  private void handleFailure(WorkflowState currentState) {
     instance = new WorkflowInstance.Builder().setState(currentState).build();
     createExecution();
-    execution.handleFailure(def, "reason");
+    execution.handleFailure("reason");
   }
 
   static class Data {

--- a/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/WorkflowStateMethodTest.java
+++ b/nflow-engine/src/test/java/io/nflow/engine/internal/workflow/WorkflowStateMethodTest.java
@@ -1,0 +1,33 @@
+package io.nflow.engine.internal.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.nflow.engine.internal.workflow.WorkflowStateMethod.StateParameter;
+
+public class WorkflowStateMethodTest {
+
+  private final WorkflowStateMethod method = new WorkflowStateMethod(null,
+      new StateParameter("foo", String.class, null, false, false),
+      new StateParameter("bar", Integer.class, null, false, false));
+
+  @Test
+  public void hasParameterReturnsTrueForMatchingName() {
+    assertTrue(method.hasParameter("foo"));
+    assertTrue(method.hasParameter("bar"));
+  }
+
+  @Test
+  public void hasParameterReturnsFalseForUnknownName() {
+    assertFalse(method.hasParameter("baz"));
+  }
+
+  @Test
+  public void hasParameterReturnsFalseWhenMethodHasNoParams() {
+    WorkflowStateMethod methodWithoutParams = new WorkflowStateMethod(null);
+
+    assertFalse(methodWithoutParams.hasParameter("foo"));
+  }
+}


### PR DESCRIPTION
`StateExecution.setVariable(...)` now throws error if called for any `@StateVar` state variables.
  - Either stop calling `StateExecution.setVariable(...)` or remove `@StateVar` state variable.
  - Previous behavior: `StateExecution.setVariable(...)` was silently ignored.